### PR TITLE
Add NumPy-style documentation for twilight planner modules

### DIFF
--- a/twilight_planner_pkg/config.py
+++ b/twilight_planner_pkg/config.py
@@ -6,8 +6,48 @@ from typing import Dict, List, Optional
 class PlannerConfig:
     """Configuration container for twilight planning.
 
-    All angles are in degrees unless otherwise noted. The planner is instrument-agnostic;
-    supply appropriate parameters for your facility.
+    Attributes
+    ----------
+    lat_deg, lon_deg, height_m : float
+        Observatory latitude, longitude, and elevation.
+    min_alt_deg : float, optional
+        Minimum altitude for targets in degrees.
+    typical_days_by_type : dict[str, int], optional
+        Mapping from supernova type to typical visibility window.
+    default_typical_days : int, optional
+        Fallback visibility window in days when type is unknown.
+    slew_small_deg : float, optional
+        Threshold for small slews in degrees.
+    slew_small_time_s : float, optional
+        Time in seconds for slews ``<=`` ``slew_small_deg``.
+    slew_rate_deg_per_s : float, optional
+        Slew rate for large moves.
+    slew_settle_s : float, optional
+        Additional settling time in seconds.
+    readout_s : float, optional
+        Detector readout time per exposure.
+    filter_change_s : float, optional
+        Overhead for a filter change in seconds.
+    filters : list[str], optional
+        Available filters in order of priority.
+    exposure_by_filter : dict[str, float], optional
+        Exposure time for each filter in seconds.
+    carousel_capacity : int, optional
+        Maximum number of filters the carousel can hold.
+    twilight_step_min : int, optional
+        Step size in minutes when sampling twilight windows.
+    evening_cap_s, morning_cap_s : float, optional
+        Time caps in seconds for evening and morning windows.
+    max_sn_per_night : int, optional
+        Maximum number of supernovae scheduled per night.
+    per_sn_cap_s : float, optional
+        Time cap per supernova in seconds.
+    min_moon_sep_by_filter : dict[str, float], optional
+        Minimum Moon separation per filter in degrees.
+    require_single_time_for_all_filters : bool, optional
+        Require one time satisfying Moon separation for all filters.
+    ra_col, dec_col, disc_col, name_col, type_col : str or None, optional
+        Overrides for catalog column names. ``None`` enables auto-detection.
     """
     # Site
     lat_deg: float

--- a/twilight_planner_pkg/main.py
+++ b/twilight_planner_pkg/main.py
@@ -13,12 +13,12 @@ from .config import PlannerConfig
 from .scheduler import plan_twilight_range_with_caps
 
 def build_parser():
-    """Build the command-line argument parser.
+    """Construct the command-line argument parser.
 
     Returns
     -------
     argparse.ArgumentParser
-        The configured argument parser.
+        Parser configured with all planner options.
     """
     p = argparse.ArgumentParser(description="LSST Twilight Planner (modular)")
     p.add_argument("--csv", required=True, help="Path to input CSV with SN list")
@@ -42,17 +42,17 @@ def build_parser():
     return p
 
 def parse_exp_map(s: str):
-    """Parse a string into a filter-to-exposure time map.
+    """Convert a comma-separated exposure mapping into a dictionary.
 
     Parameters
     ----------
     s : str
-        A comma-separated string of key:value pairs, e.g., "g:5,r:10".
+        Comma-separated list of ``filter:time`` pairs (e.g., ``"g:5,r:10"``).
 
     Returns
     -------
     dict[str, float]
-        A dictionary mapping filter names to exposure times in seconds.
+        Mapping from filter name to exposure time in seconds.
     """
     m = {}
     if s.strip():
@@ -62,9 +62,10 @@ def parse_exp_map(s: str):
     return m
 
 def main():
-    """Main entry point for the command-line interface.
+    """Run the command-line planner.
 
-    Parses arguments, builds the configuration, and runs the planner.
+    Parses arguments, builds a :class:`PlannerConfig`, and writes
+    schedule files to the output directory.
     """
     args = build_parser().parse_args()
     exp_map = parse_exp_map(args.exp)

--- a/twilight_planner_pkg/scheduler.py
+++ b/twilight_planner_pkg/scheduler.py
@@ -25,6 +25,30 @@ def plan_twilight_range_with_caps(
     cfg: PlannerConfig,
     verbose: bool = True,
 ):
+    """Generate a twilight observing plan over a date range with per-window time caps.
+
+    Parameters
+    ----------
+    csv_path : str
+        Path to the CSV file listing supernovae.
+    outdir : str
+        Directory where output CSVs are written.
+    start_date : str
+        Inclusive start date in ``YYYY-MM-DD`` (UTC).
+    end_date : str
+        Inclusive end date in ``YYYY-MM-DD`` (UTC).
+    cfg : PlannerConfig
+        Configuration with site, filter, and timing parameters.
+    verbose : bool, optional
+        If ``True``, print progress messages.
+
+    Returns
+    -------
+    pernight_df : pandas.DataFrame
+        Planned observations for each supernova.
+    nights_df : pandas.DataFrame
+        Summary of time usage for each night and window.
+    """
     Path(outdir).mkdir(parents=True, exist_ok=True)
     raw = pd.read_csv(csv_path)
     df = standardize_columns(raw, cfg)


### PR DESCRIPTION
## Summary
- Document PlannerConfig dataclass fields using NumPy-style docstring
- Add comprehensive docstrings for scheduling, I/O utilities, CLI, and astronomy helpers

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689781ebc1d48321bcb30f8882e69210