### PR TITLE
Add NumPy-style documentation for twilight planner modules

### DIFF
--- a/twilight_planner_pkg/README.md
+++ b/twilight_planner_pkg/README.md
@@ -1,26 +1,110 @@
-# Modular LSST Twilight Planner
+# LSST Twilight Planner
 
-This is a split, maintainable version of your original `twilight_planner.py`.
+Modular planner for scheduling LSST twilight observations of supernovae.
 
-## Layout
-- `config.py` — `PlannerConfig` dataclass for all knobs.
-- `io_utils.py` — CSV column detection, RA/Dec normalization, discovery date parsing.
-- `astro_utils.py` — astronomy helpers (twilight windows, moon separation checks, slews, etc.).
-- `scheduler.py` — core scheduler `plan_twilight_range_with_caps(...)` orchestrating the plan.
-- `main.py` — lightweight CLI entry point.
+## Installation
 
-## Quick start (example)
 ```bash
-python -m twilight_planner_pkg.main   --csv /mnt/data/ATLAS_2021_to25_cleaned.csv   --out /mnt/data/out   --start 2024-01-01 --end 2024-01-07   --lat -30.2446 --lon -70.7494 --height 2663   --filters g,r,i,z   --exp g:5,r:5,i:5,z:5   --min_alt 20 --evening_cap 600 --morning_cap 600 --per_sn_cap 120 --max_sn 10
+pip install -r requirements.txt
 ```
 
-You can also import it in notebooks:
+## Usage
+
+```bash
+python -m twilight_planner_pkg.main --csv your.csv --out results \
+    --start 2024-01-01 --end 2024-01-07 \
+    --lat -30.2446 --lon -70.7494 --height 2663 \
+    --filters g,r,i,z --exp g:5,r:5,i:5,z:5 \
+    --min_alt 20 --evening_cap 600 --morning_cap 600 \
+    --per_sn_cap 120 --max_sn 10
+```
+
+### Notebook example
+
 ```python
 from twilight_planner_pkg.config import PlannerConfig
 from twilight_planner_pkg.scheduler import plan_twilight_range_with_caps
 
 cfg = PlannerConfig(lat_deg=-30.2446, lon_deg=-70.7494, height_m=2663)
-plan_twilight_range_with_caps(
-    '/path/to/your.csv', '/tmp/out', '2024-01-01', '2024-01-07', cfg
-)
+plan_twilight_range_with_caps('/path/to/your.csv', '/tmp/out',
+                              '2024-01-01', '2024-01-07', cfg)
 ```
+
+## How It Works
+
+### Inputs & Preprocessing
+
+* **Inputs** – CSV path, output directory, UTC start/end dates, and a
+  `PlannerConfig` describing site details, slews/overheads, filters, caps, and
+  column overrides.
+* **Column handling** – RA, Dec, discovery date (ISO or MJD), name, and type
+  columns are auto-detected if not explicitly supplied.
+* **Units** – RA/Dec values are parsed to degrees with a series-level inference
+  report that warns about ambiguous ranges or mixed types.
+* **Derived columns** – `RA_deg`, `Dec_deg`, `discovery_datetime` (UTC),
+  `Name`, and `SN_type_raw` are added for later stages.
+
+### Eligibility
+
+* A target must reach `max_alt_deg` above `min_alt_deg` (default 20°).
+* Supernovae lacking a valid `discovery_datetime` are skipped.
+* An object remains eligible for `ceil(1.2 × days)` after discovery, where the
+  base `days` comes from `typical_days_by_type` or a default value.
+
+### Best-Time Selection
+
+* Twilight windows are spans when the Sun altitude is between −18° and 0°.
+* Windows are sampled every `twilight_step_min` minutes to test altitude and
+  Moon separation constraints.
+* The time with the highest altitude satisfying `alt ≥ min_alt_deg` and Moon
+  rules (Moon below horizon or sufficiently separated) is chosen.
+
+### Selection & Scheduling
+
+* Rank visible supernovae by their best altitude and keep the top
+  `max_sn_per_night` globally.
+* Split targets by window (index 0 morning, 1 evening) and order within each
+  group by a greedy nearest-neighbor search on great-circle distance.
+* Enforce per-window caps (`morning_cap_s`, `evening_cap_s`) while scheduling.
+* Each target must fit within `per_sn_cap_s`; filters are trimmed greedily if
+  needed.
+
+### Slew & Overhead Model
+
+* **Slew time** – if separation ≤ `slew_small_deg`, cost is `slew_small_time_s`;
+  otherwise add rate-based time plus `slew_settle_s`.
+* **Exposure time** – sum of `exposure_by_filter` values for used filters.
+* **Additional costs** – `readout_s` per filter and `filter_change_s` per change.
+* **Per-SN total** – slew + exposures + readout + filter changes.
+
+### Filters & Exposure Assignment
+
+* Filters are requested in priority order. If adding another filter would exceed
+  `per_sn_cap_s`, the planner stops and uses the current set (ensuring at least
+  one filter when possible).
+* If the requested filter count exceeds `carousel_capacity`, a warning is
+  emitted but planning continues.
+
+### Outputs
+
+* **Per-SN plan** – CSV and DataFrame listing date, window, chosen time,
+  altitude, filters, and detailed time budget components.
+* **Night summary** – CSV and DataFrame with counts of candidates vs. planned
+  targets and cumulative time per window.
+
+## Layout
+
+* `config.py` — `PlannerConfig` dataclass for all knobs.
+* `io_utils.py` — CSV column detection, RA/Dec normalization, discovery date
+  parsing.
+* `astro_utils.py` — astronomy helpers (twilight windows, moon separation
+  checks, slews, etc.).
+* `scheduler.py` — core scheduler `plan_twilight_range_with_caps(...)`
+  orchestrating the plan.
+* `main.py` — lightweight CLI entry point.
+
+## Documentation
+
+All modules include NumPy-style docstrings detailing parameters, return values,
+and algorithmic behavior for reference.
+

--- a/twilight_planner_pkg/config.py
+++ b/twilight_planner_pkg/config.py
@@ -6,8 +6,48 @@ from typing import Dict, List, Optional
 class PlannerConfig:
     """Configuration container for twilight planning.
 
-    All angles are in degrees unless otherwise noted. The planner is instrument-agnostic;
-    supply appropriate parameters for your facility.
+    Attributes
+    ----------
+    lat_deg, lon_deg, height_m : float
+        Observatory latitude, longitude, and elevation.
+    min_alt_deg : float, optional
+        Minimum altitude for targets in degrees.
+    typical_days_by_type : dict[str, int], optional
+        Mapping from supernova type to typical visibility window.
+    default_typical_days : int, optional
+        Fallback visibility window in days when type is unknown.
+    slew_small_deg : float, optional
+        Threshold for small slews in degrees.
+    slew_small_time_s : float, optional
+        Time in seconds for slews ``<=`` ``slew_small_deg``.
+    slew_rate_deg_per_s : float, optional
+        Slew rate for large moves.
+    slew_settle_s : float, optional
+        Additional settling time in seconds.
+    readout_s : float, optional
+        Detector readout time per exposure.
+    filter_change_s : float, optional
+        Overhead for a filter change in seconds.
+    filters : list[str], optional
+        Available filters in order of priority.
+    exposure_by_filter : dict[str, float], optional
+        Exposure time for each filter in seconds.
+    carousel_capacity : int, optional
+        Maximum number of filters the carousel can hold.
+    twilight_step_min : int, optional
+        Step size in minutes when sampling twilight windows.
+    evening_cap_s, morning_cap_s : float, optional
+        Time caps in seconds for evening and morning windows.
+    max_sn_per_night : int, optional
+        Maximum number of supernovae scheduled per night.
+    per_sn_cap_s : float, optional
+        Time cap per supernova in seconds.
+    min_moon_sep_by_filter : dict[str, float], optional
+        Minimum Moon separation per filter in degrees.
+    require_single_time_for_all_filters : bool, optional
+        Require one time satisfying Moon separation for all filters.
+    ra_col, dec_col, disc_col, name_col, type_col : str or None, optional
+        Overrides for catalog column names. ``None`` enables auto-detection.
     """
     # Site
     lat_deg: float

--- a/twilight_planner_pkg/main.py
+++ b/twilight_planner_pkg/main.py
@@ -13,12 +13,12 @@ from .config import PlannerConfig
 from .scheduler import plan_twilight_range_with_caps
 
 def build_parser():
-    """Build the command-line argument parser.
+    """Construct the command-line argument parser.
 
     Returns
     -------
     argparse.ArgumentParser
-        The configured argument parser.
+        Parser configured with all planner options.
     """
     p = argparse.ArgumentParser(description="LSST Twilight Planner (modular)")
     p.add_argument("--csv", required=True, help="Path to input CSV with SN list")
@@ -42,17 +42,17 @@ def build_parser():
     return p
 
 def parse_exp_map(s: str):
-    """Parse a string into a filter-to-exposure time map.
+    """Convert a comma-separated exposure mapping into a dictionary.
 
     Parameters
     ----------
     s : str
-        A comma-separated string of key:value pairs, e.g., "g:5,r:10".
+        Comma-separated list of ``filter:time`` pairs (e.g., ``"g:5,r:10"``).
 
     Returns
     -------
     dict[str, float]
-        A dictionary mapping filter names to exposure times in seconds.
+        Mapping from filter name to exposure time in seconds.
     """
     m = {}
     if s.strip():
@@ -62,9 +62,10 @@ def parse_exp_map(s: str):
     return m
 
 def main():
-    """Main entry point for the command-line interface.
+    """Run the command-line planner.
 
-    Parses arguments, builds the configuration, and runs the planner.
+    Parses arguments, builds a :class:`PlannerConfig`, and writes
+    schedule files to the output directory.
     """
     args = build_parser().parse_args()
     exp_map = parse_exp_map(args.exp)

--- a/twilight_planner_pkg/scheduler.py
+++ b/twilight_planner_pkg/scheduler.py
@@ -25,6 +25,30 @@ def plan_twilight_range_with_caps(
     cfg: PlannerConfig,
     verbose: bool = True,
 ):
+    """Generate a twilight observing plan over a date range with per-window time caps.
+
+    Parameters
+    ----------
+    csv_path : str
+        Path to the CSV file listing supernovae.
+    outdir : str
+        Directory where output CSVs are written.
+    start_date : str
+        Inclusive start date in ``YYYY-MM-DD`` (UTC).
+    end_date : str
+        Inclusive end date in ``YYYY-MM-DD`` (UTC).
+    cfg : PlannerConfig
+        Configuration with site, filter, and timing parameters.
+    verbose : bool, optional
+        If ``True``, print progress messages.
+
+    Returns
+    -------
+    pernight_df : pandas.DataFrame
+        Planned observations for each supernova.
+    nights_df : pandas.DataFrame
+        Summary of time usage for each night and window.
+    """
     Path(outdir).mkdir(parents=True, exist_ok=True)
     raw = pd.read_csv(csv_path)
     df = standardize_columns(raw, cfg)


### PR DESCRIPTION
## Summary
- Document PlannerConfig dataclass fields using NumPy-style docstring
- Add comprehensive docstrings for scheduling, I/O utilities, CLI, and astronomy helpers
- Expand README with installation instructions, CLI usage, and planning algorithm overview

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689781ebc1d48321bcb30f8882e69210