### PR TITLE
Add GitHub Actions workflow for tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,23 @@
+name: Tests
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.9", "3.10", "3.11"]
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+      - name: Run tests
+        run: pytest


### PR DESCRIPTION
## Summary
- run tests via GitHub Actions on push and pull_request
- use Python 3.9, 3.10, and 3.11, installing requirements.txt before running pytest

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6898d98e3c1c8321bb2fb8763a30b13b