### PR TITLE
Add PlannerConfig tests

### DIFF
--- a/twilight_planner_pkg/tests/test_config.py
+++ b/twilight_planner_pkg/tests/test_config.py
@@ -1,0 +1,22 @@
+import pathlib, sys
+
+# Ensure package root is importable
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[2]))
+
+from twilight_planner_pkg.config import PlannerConfig
+
+
+def test_default_config_values():
+    cfg = PlannerConfig(10.0, 20.0, 30.0)
+    assert cfg.filters == ["g", "r", "i", "z"]
+    assert cfg.exposure_by_filter == {"g": 5.0, "r": 5.0, "i": 5.0, "z": 5.0}
+    assert cfg.evening_cap_s == 600.0
+
+
+def test_custom_overrides():
+    custom_filters = ["g", "r"]
+    custom_typical = {"Ia": 40}
+    cfg = PlannerConfig(10.0, 20.0, 30.0, filters=custom_filters,
+                        typical_days_by_type=custom_typical)
+    assert cfg.filters == custom_filters
+    assert cfg.typical_days_by_type == custom_typical


### PR DESCRIPTION
## Summary
- test default PlannerConfig values for filters, exposures, and evening caps
- ensure PlannerConfig honors custom filter lists and typical-day overrides

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6898d9774ee08321b4254a7253b5179e