### PR TITLE
Expand priority tracker tests for escalation and LC completion

### DIFF
--- a/twilight_planner_pkg/tests/test_priority.py
+++ b/twilight_planner_pkg/tests/test_priority.py
@@ -40,3 +40,27 @@ def test_ia_requires_lc_goal():
     t.record_detection("SN4", 50, ["g"])
     assert t.score("SN4", sn_type="Ia") == 0.0
 
+
+def test_update_aliases_record_detection():
+    assert PriorityTracker.update is PriorityTracker.record_detection
+
+
+def test_score_strategy_lc_escalates_without_detections():
+    t = tracker()
+    assert t.score("SN5", strategy="lc") == 1.0
+    assert t.history["SN5"].escalated is True
+
+
+def test_score_zero_after_lc_completion_regardless_type():
+    t = tracker()
+    for _ in range(5):
+        t.record_detection("SN6", 60, ["g"])
+    assert t.score("SN6", strategy="lc") == 0.0
+    for typ in (None, "Ia", "II"):
+        assert t.score("SN6", sn_type=typ) == 0.0
+
+
+def test_repeated_filter_usage_does_not_meet_hybrid():
+    t = tracker()
+    t.record_detection("SN7", 150, ["g", "g"])
+    assert t.score("SN7", sn_type="II") == 1.0


### PR DESCRIPTION
## Summary
- Add alias test ensuring `update` maps to `record_detection`
- Cover `score` escalation with `strategy="lc"` and no detections
- Ensure LC goal completion returns zero priority for any SN type
- Include edge cases for repeated filter usage

## Testing
- `python -m pytest -q` *(fails: python: No such file or directory)*
- `python3 -m pytest -q` *(fails: python3: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6898d96c8c14832191c0ea9cade84683