### PR TITLE
Add tests for astro utilities

### DIFF
--- a/twilight_planner_pkg/tests/test_astro_utils.py
+++ b/twilight_planner_pkg/tests/test_astro_utils.py
@@ -1,0 +1,118 @@
+import pathlib, sys
+from datetime import datetime, timezone
+
+# Ensure package root is importable
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[2]))
+
+import pytest
+import astropy.units as u
+from astropy.coordinates import EarthLocation, AltAz, get_sun, get_body, SkyCoord
+from astropy.time import Time
+
+from twilight_planner_pkg.astro_utils import (
+    twilight_windows_astro,
+    great_circle_sep_deg,
+    slew_time_seconds,
+    per_sn_time_seconds,
+    choose_filters_with_cap,
+    parse_sn_type_to_window_days,
+    _best_time_with_moon,
+)
+from twilight_planner_pkg.config import PlannerConfig
+
+
+# Observatory location (CTIO)
+LOC = EarthLocation(lat=-30.1652778 * u.deg, lon=-70.815 * u.deg, height=2215 * u.m)
+
+
+def test_twilight_windows_astro():
+    date = datetime(2024, 1, 15, tzinfo=timezone.utc)
+    windows = twilight_windows_astro(date, LOC)
+    assert windows == sorted(windows, key=lambda w: w[0])
+    assert all(s < e for s, e in windows)
+    assert windows
+    for s, e in windows:
+        mid = s + (e - s) / 2
+        alt = get_sun(Time(mid)).transform_to(AltAz(obstime=Time(mid), location=LOC)).alt.deg
+        assert -18 < alt < 0
+
+
+def test_great_circle_sep_deg():
+    assert great_circle_sep_deg(0, 0, 90, 0) == pytest.approx(90.0)
+    assert great_circle_sep_deg(10, 10, 10, 10) == pytest.approx(0.0)
+
+
+def test_slew_time_seconds():
+    params = dict(small_deg=5, small_time=1, rate_deg_per_s=2, settle_s=0.5)
+    assert slew_time_seconds(0, **params) == 0.0
+    assert slew_time_seconds(3, **params) == pytest.approx(1.5)
+    assert slew_time_seconds(10, **params) == pytest.approx(4.0)
+
+
+def test_per_sn_time_and_filter_cap():
+    cfg = PlannerConfig(
+        lat_deg=0,
+        lon_deg=0,
+        height_m=0,
+        slew_small_deg=5,
+        slew_small_time_s=1,
+        slew_rate_deg_per_s=1,
+        slew_settle_s=1,
+        readout_s=1,
+        filter_change_s=5,
+        exposure_by_filter={"g": 10, "r": 10},
+        filters=["g", "r"],
+    )
+    total, slew, exptime, readout, fchanges = per_sn_time_seconds(["g", "r"], sep_deg=2, cfg=cfg)
+    assert (total, slew, exptime, readout, fchanges) == pytest.approx((29, 2, 20, 2, 5))
+
+    used, timing = choose_filters_with_cap(["g", "r"], sep_deg=2, cap_s=40, cfg=cfg)
+    assert used == ["g", "r"]
+    assert timing["total_s"] == pytest.approx(29)
+
+    used, timing = choose_filters_with_cap(["g", "r"], sep_deg=2, cap_s=20, cfg=cfg)
+    assert used == ["g"]
+    assert timing["total_s"] == pytest.approx(13)
+
+    used, timing = choose_filters_with_cap(["g", "r"], sep_deg=2, cap_s=5, cfg=cfg)
+    assert used == ["g"]
+    assert timing["total_s"] == pytest.approx(13)
+
+
+def test_parse_sn_type_to_window_days():
+    cfg = PlannerConfig(
+        lat_deg=0,
+        lon_deg=0,
+        height_m=0,
+        typical_days_by_type={"Ia": 25},
+        default_typical_days=10,
+    )
+    assert parse_sn_type_to_window_days("Type Ia", cfg) == 30
+    assert parse_sn_type_to_window_days("Ib", cfg) == 12
+    assert parse_sn_type_to_window_days("", cfg) == 12
+    assert parse_sn_type_to_window_days(None, cfg) == 12
+
+
+def test_best_time_with_moon():
+    window = (
+        datetime(2024, 1, 15, 0, 0, tzinfo=timezone.utc),
+        datetime(2024, 1, 15, 1, 0, tzinfo=timezone.utc),
+    )
+    target_far = SkyCoord(74.817 * u.deg, -9.76 * u.deg)
+    alt, t = _best_time_with_moon(
+        target_far, window, LOC, step_min=30, min_alt_deg=30, min_moon_sep_deg=30
+    )
+    assert t is not None and window[0] <= t <= window[1]
+    ts = Time(t)
+    altaz = AltAz(obstime=ts, location=LOC)
+    alt_check = target_far.transform_to(altaz).alt.deg
+    moon_coord = get_body("moon", ts, location=LOC).transform_to(altaz)
+    sep = target_far.transform_to(altaz).separation(moon_coord).deg
+    assert alt_check >= 30
+    assert sep >= 30
+
+    target_near = SkyCoord(344.81747793145 * u.deg, -9.76040058827 * u.deg)
+    alt, t = _best_time_with_moon(
+        target_near, window, LOC, step_min=30, min_alt_deg=20, min_moon_sep_deg=30
+    )
+    assert t is None


### PR DESCRIPTION
## Summary
- add tests validating twilight windows, coordinate separation, slew timing, per-SN timing, filter capping, SN type parsing, and moon constraints

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6898d96b079c83218518dfb600d95a48