### PR TITLE
Implement filter-aware, moon-aware LSST twilight planner

### DIFF
--- a/twilight_planner_pkg/priority.py
+++ b/twilight_planner_pkg/priority.py
@@ -1,5 +1,13 @@
 from __future__ import annotations
-"""Utilities for tracking per-supernova detection history and priorities."""
+"""Utilities for tracking per-supernova detection history and priorities.
+
+The planner keeps a small record for each supernova describing how many
+detections have been taken, in which filters and the accumulated exposure time.
+From this history a simple priority score is derived; a value of ``1`` means
+the SN should be observed in the current strategy stage, while ``0`` indicates
+that the goal for the stage has been met.
+"""
+
 from dataclasses import dataclass, field
 from typing import Dict, Optional, Set, List
 
@@ -18,16 +26,11 @@ class _SNHistory:
 class PriorityTracker:
     """Track detections and compute dynamic priority scores.
 
-    Parameters
-    ----------
-    hybrid_detections : int, optional
-        Minimum detections (across ≥2 filters) for the Hybrid goal.
-    hybrid_exposure_s : float, optional
-        Total exposure seconds triggering the Hybrid goal.
-    lc_detections : int, optional
-        Detections required for the LSST-only light-curve goal.
-    lc_exposure_s : float, optional
-        Exposure seconds for the LSST-only goal (must also span ≥2 filters).
+    ``detections`` counts the number of individual filter exposures recorded
+    for the SN.  The :meth:`score` method returns ``1.0`` when a supernova still
+    requires attention under the current strategy (Hybrid or light-curve) and
+    ``0.0`` once the respective goal has been satisfied.  :meth:`peek_score`
+    provides the same evaluation without mutating the internal state.
     """
 
     hybrid_detections: int = 2
@@ -46,14 +49,13 @@ class PriorityTracker:
     # alias for clarity
     update = record_detection
 
-    def score(self, name: str, sn_type: Optional[str] = None, strategy: str = "hybrid") -> float:
-        """Return the priority score for a supernova."""
-        hist = self.history.setdefault(name, _SNHistory())
+    def _score(self, hist: _SNHistory, sn_type: Optional[str], strategy: str, mutate: bool) -> float:
+        """Internal helper implementing the scoring rules."""
 
-        if strategy == "lc":
+        escalated = hist.escalated or strategy == "lc"
+        if strategy == "lc" and mutate:
             hist.escalated = True
-
-        if not hist.escalated:
+        if not escalated:
             met_hybrid = (
                 (hist.detections >= self.hybrid_detections and len(hist.filters) >= 2)
                 or hist.exposure_s >= self.hybrid_exposure_s
@@ -61,7 +63,9 @@ class PriorityTracker:
             if not met_hybrid:
                 return 1.0
             if sn_type and "ia" in sn_type.lower() or strategy == "lc":
-                hist.escalated = True
+                if mutate:
+                    hist.escalated = True
+                escalated = True
             else:
                 return 0.0
 
@@ -70,3 +74,15 @@ class PriorityTracker:
             or (hist.exposure_s >= self.lc_exposure_s and len(hist.filters) >= 2)
         )
         return 0.0 if met_lc else 1.0
+
+    def score(self, name: str, sn_type: Optional[str] = None, strategy: str = "hybrid") -> float:
+        """Return the priority score for a supernova and update its state."""
+        hist = self.history.setdefault(name, _SNHistory())
+        return self._score(hist, sn_type, strategy, mutate=True)
+
+    def peek_score(self, name: str, sn_type: Optional[str] = None, strategy: str = "hybrid") -> float:
+        """Return the score without updating the internal history."""
+        hist = self.history.setdefault(name, _SNHistory())
+        # Work on a shallow copy so the caller does not see side effects
+        tmp = _SNHistory(hist.detections, hist.exposure_s, set(hist.filters), hist.escalated)
+        return self._score(tmp, sn_type, strategy, mutate=False)

--- a/twilight_planner_pkg/tests/test_config.py
+++ b/twilight_planner_pkg/tests/test_config.py
@@ -8,9 +8,9 @@ from twilight_planner_pkg.config import PlannerConfig
 
 def test_default_config_values():
     cfg = PlannerConfig(10.0, 20.0, 30.0)
-    assert cfg.filters == ["g", "r", "i", "z"]
-    assert cfg.exposure_by_filter == {"g": 5.0, "r": 5.0, "i": 5.0, "z": 5.0}
-    assert cfg.evening_cap_s == 600.0
+    assert cfg.filters == ["g", "r", "i", "z", "y"]
+    assert cfg.exposure_by_filter["g"] == 15.0
+    assert cfg.evening_cap_s == 1800.0
 
 
 def test_custom_overrides():

--- a/twilight_planner_pkg/tests/test_planner_features.py
+++ b/twilight_planner_pkg/tests/test_planner_features.py
@@ -1,0 +1,104 @@
+import pathlib
+import sys
+from datetime import datetime, timezone, timedelta
+import warnings
+
+import pandas as pd
+import astropy.units as u
+from astropy.coordinates import SkyCoord, EarthLocation
+
+# Ensure package root is importable
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[2]))
+
+from twilight_planner_pkg.config import PlannerConfig
+from twilight_planner_pkg.astro_utils import (
+    _best_time_with_moon,
+    choose_filters_with_cap,
+    pick_first_filter_for_target,
+)
+from twilight_planner_pkg.priority import PriorityTracker
+from twilight_planner_pkg.scheduler import plan_twilight_range_with_caps
+
+
+def test_best_time_with_moon_no_warning():
+    sc = SkyCoord(0 * u.deg, 0 * u.deg)
+    now = datetime(2024, 1, 1, tzinfo=timezone.utc)
+    window = (now, now + timedelta(hours=1))
+    loc = EarthLocation(lat=0 * u.deg, lon=0 * u.deg, height=0 * u.m)
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("error")
+        alt, t = _best_time_with_moon(sc, window, loc, 10, 0.0, 0.0)
+    assert w == []
+    assert isinstance(alt, float)
+
+
+def test_filter_capacity_drop(tmp_path, capsys):
+    df = pd.DataFrame(
+        {
+            "ra": [0.0],
+            "dec": [0.0],
+            "discoverydate": ["2023-12-01T00:00:00Z"],
+            "name": ["SN1"],
+            "type": ["Ia"],
+        }
+    )
+    csv = tmp_path / "cat.csv"
+    df.to_csv(csv, index=False)
+    cfg = PlannerConfig(
+        filters=["u", "g", "r", "i", "z", "y"],
+        carousel_capacity=5,
+        morning_cap_s=100.0,
+        evening_cap_s=100.0,
+    )
+    plan_twilight_range_with_caps(str(csv), tmp_path, "2024-01-01", "2024-01-01", cfg, verbose=True)
+    captured = capsys.readouterr()
+    assert "dropping u" in captured.out.lower()
+    assert "u" not in cfg.filters
+
+
+def test_cross_vs_internal_changes():
+    cfg = PlannerConfig()
+    used1, t1 = choose_filters_with_cap(["z"], 0.0, 1000.0, cfg)
+    used2, t2 = choose_filters_with_cap(["i"], 0.0, 1000.0, cfg, current_filter=used1[-1])
+    used3, t3 = choose_filters_with_cap(["z"], 0.0, 1000.0, cfg, current_filter=used2[-1])
+    cross = sum(int(x["cross_filter_change_s"] > 0) for x in [t1, t2, t3])
+    assert cross == 2
+
+
+def test_pick_first_filter_priority():
+    cfg = PlannerConfig()
+    tracker = PriorityTracker()
+    tracker.record_detection("SN_A", 15.0, ["g"])
+    f1 = pick_first_filter_for_target("SN_A", "Ia", tracker, ["g", "r"], cfg)
+    assert f1 == "r"  # missing second filter
+
+    tracker.record_detection("SN_B", 15.0, ["g", "r"])
+    tracker.history["SN_B"].escalated = True
+    f2 = pick_first_filter_for_target("SN_B", "Ia", tracker, ["g", "r"], cfg, current_filter="g")
+    assert f2 == "r"  # red preference in LC stage
+
+
+def test_per_sn_cap_allows_one():
+    cfg = PlannerConfig()
+    used, timing = choose_filters_with_cap(["g", "r"], 0.0, 1.0, cfg)
+    assert used == ["g"]
+    assert timing["total_s"] > 1.0
+
+
+def test_window_cap_skips_last(tmp_path):
+    df = pd.DataFrame(
+        {
+            "ra": [0.0, 0.0],
+            "dec": [0.0, 0.0],
+            "discoverydate": ["2023-12-01T00:00:00Z", "2023-12-01T00:00:00Z"],
+            "name": ["SN1", "SN2"],
+            "type": ["Ia", "Ia"],
+        }
+    )
+    csv = tmp_path / "cat.csv"
+    df.to_csv(csv, index=False)
+    cfg = PlannerConfig(filters=["g"], morning_cap_s=20.0, evening_cap_s=20.0)
+    pernight, nights = plan_twilight_range_with_caps(
+        str(csv), tmp_path, "2024-01-01", "2024-01-01", cfg, verbose=False
+    )
+    assert nights["n_planned"].max() <= 1


### PR DESCRIPTION
## Summary
- overhaul configuration with LSST-specific defaults and compatibility for legacy args
- add filter- and moon-aware utilities, including first-filter choice and capped visit timing
- enrich scheduler with carousel capacity handling and detailed timing diagnostics
- document priority tracker semantics and expose peek_score for scoring without side effects
- extend test suite for moon separation, filter capacity, priority behaviour, and cap enforcement

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689b074564f4832186987e5dbc1c04d0