### PR TITLE
Model twilight sky brightness as function of Sun altitude

### DIFF
--- a/twilight_planner_pkg/photom_rubin.py
+++ b/twilight_planner_pkg/photom_rubin.py
@@ -1,14 +1,26 @@
 from __future__ import annotations
+
+import math
 from dataclasses import dataclass
 from typing import Dict, Optional
-import math
 
 from .astro_utils import airmass_from_alt_deg
 
 
 @dataclass
 class PhotomConfig:
-    """Configuration parameters for Rubin photometric calculations."""
+    """Configuration parameters for Rubin photometric calculations.
+
+    Attributes
+    ----------
+    npe_pixel_saturate: int
+        Hard pixel full-well capacity in electrons where exposure must be
+        shortened to avoid saturation (~100 ke-).
+    npe_pixel_warn_nonlinear: int
+        Non-linearity warning threshold in electrons; exposures predicting a
+        per-pixel charge above this level (~80 ke-) will be flagged but not
+        forcibly reduced unless the hard cap is exceeded.
+    """
 
     pixel_scale_arcsec: float = 0.2
     zpt1s: Dict[str, float] | None = None
@@ -17,16 +29,38 @@ class PhotomConfig:
     read_noise_e: float = 9.0
     gain_e_per_adu: float = 1.0
     zpt_err_mag: float = 0.005
-    npe_pixel_saturate: int = 90000
+    npe_pixel_saturate: int = 100_000
+    npe_pixel_warn_nonlinear: int = 80_000
     sky_mag_override: Optional[float] = None
 
     def __post_init__(self):
         if self.zpt1s is None:
-            self.zpt1s = {"u":26.52,"g":28.51,"r":28.36,"i":28.17,"z":27.78,"y":26.82}
+            self.zpt1s = {
+                "u": 26.52,
+                "g": 28.51,
+                "r": 28.36,
+                "i": 28.17,
+                "z": 27.78,
+                "y": 26.82,
+            }
         if self.k_m is None:
-            self.k_m = {"u":0.50,"g":0.17,"r":0.10,"i":0.07,"z":0.06,"y":0.06}
+            self.k_m = {
+                "u": 0.50,
+                "g": 0.17,
+                "r": 0.10,
+                "i": 0.07,
+                "z": 0.06,
+                "y": 0.06,
+            }
         if self.fwhm_eff is None:
-            self.fwhm_eff = {"u":0.90,"g":0.85,"r":0.83,"i":0.83,"z":0.85,"y":0.90}
+            self.fwhm_eff = {
+                "u": 0.90,
+                "g": 0.85,
+                "r": 0.83,
+                "i": 0.83,
+                "z": 0.85,
+                "y": 0.90,
+            }
 
 
 @dataclass
@@ -56,17 +90,21 @@ def central_pixel_fraction_gaussian(fwhm_arcsec: float, pix_arcsec: float) -> fl
     return max(1e-6, min(1.0, erf * erf))
 
 
-def epoch_zeropoints(zpt1s_pe: float, t_exp_s: float, k_m: float, X: float, gain: float) -> tuple[float, float]:
+def epoch_zeropoints(
+    zpt1s_pe: float, t_exp_s: float, k_m: float, X: float, gain: float
+) -> tuple[float, float]:
     """Return zeropoints in electrons and ADU."""
     ZPT_pe = zpt1s_pe + 2.5 * math.log10(max(1e-3, t_exp_s)) - k_m * (X - 1.0)
     ZPTAVG = ZPT_pe - 2.5 * math.log10(max(1e-6, gain))
     return ZPT_pe, ZPTAVG
 
 
-def sky_rms_adu_per_pix(m_sky_arcsec2: float, ZPT_pe: float, pixel_scale_arcsec: float, gain: float) -> float:
+def sky_rms_adu_per_pix(
+    m_sky_arcsec2: float, ZPT_pe: float, pixel_scale_arcsec: float, gain: float
+) -> float:
     """Sky-background RMS in ADU per pixel."""
 
-    area = pixel_scale_arcsec ** 2
+    area = pixel_scale_arcsec**2
     counts_e = 10 ** (-0.4 * (m_sky_arcsec2 - ZPT_pe)) * area
     return math.sqrt(max(0.0, counts_e)) / gain
 
@@ -89,10 +127,14 @@ def compute_epoch_photom(
     """Compute photometric parameters for a single exposure."""
 
     X = airmass_from_alt_deg(alt_deg)
-    ZPT_pe, ZPTAVG = epoch_zeropoints(cfg.zpt1s[band], t_exp_s, cfg.k_m[band], X, cfg.gain_e_per_adu)
+    ZPT_pe, ZPTAVG = epoch_zeropoints(
+        cfg.zpt1s[band], t_exp_s, cfg.k_m[band], X, cfg.gain_e_per_adu
+    )
     fwhm = fwhm_eff_arcsec or cfg.fwhm_eff[band]
     nea = nea_pixels(fwhm, cfg.pixel_scale_arcsec)
-    SKYSIG = sky_rms_adu_per_pix(sky_mag_arcsec2, ZPT_pe, cfg.pixel_scale_arcsec, cfg.gain_e_per_adu)
+    SKYSIG = sky_rms_adu_per_pix(
+        sky_mag_arcsec2, ZPT_pe, cfg.pixel_scale_arcsec, cfg.gain_e_per_adu
+    )
     RDNOISE = cfg.read_noise_e / cfg.gain_e_per_adu
     return EpochPhotom(
         ZPTAVG=ZPTAVG,
@@ -114,15 +156,69 @@ def cap_exposure_for_saturation(
     cfg: PhotomConfig,
     fwhm_eff_arcsec: float | None = None,
     min_exp_s: float = 1.0,
-) -> float:
-    """Return t_exp_s if safe, else a scaled exposure avoiding saturation."""
+) -> tuple[float, set[str]]:
+    """Return a safe exposure time capped to avoid source or sky saturation.
+
+    Parameters
+    ----------
+    band: str
+        Photometric band ("g", "r", ...).
+    t_exp_s: float
+        Proposed exposure time in seconds.
+    alt_deg: float
+        Altitude of the target in degrees.
+    src_mag: float
+        Apparent magnitude of the source.
+    sky_mag_arcsec2: float
+        Sky surface brightness in mag/arcsec^2.
+    cfg: PhotomConfig
+        Photometric configuration parameters.
+    fwhm_eff_arcsec: float, optional
+        Effective seeing FWHM in arcsec. Defaults to config value.
+    min_exp_s: float, default 1.0
+        Minimum allowable exposure time in seconds.
+
+    Returns
+    -------
+    tuple
+        ``(t, flags)`` where ``t`` is the exposure time after applying the
+        saturation policy and ``flags`` is a set of strings.  ``"sat_guard"``
+        indicates the exposure was shortened to respect the hard cap
+        (``cfg.npe_pixel_saturate`` ≈ 100 ke-). ``"warn_nonlinear"`` marks
+        exposures that fall in the non-linear 80–100 ke- range but do not
+        require shortening.
+    """
+    flags: set[str] = set()
     t = max(min_exp_s, t_exp_s)
-    for _ in range(3):
-        eph = compute_epoch_photom(band, t, alt_deg, sky_mag_arcsec2, cfg, fwhm_eff_arcsec)
-        frac = central_pixel_fraction_gaussian(fwhm_eff_arcsec or cfg.fwhm_eff[band], cfg.pixel_scale_arcsec)
+    max_e = 0.0
+    for _ in range(10):
+        eph = compute_epoch_photom(
+            band, t, alt_deg, sky_mag_arcsec2, cfg, fwhm_eff_arcsec
+        )
+        frac = central_pixel_fraction_gaussian(
+            fwhm_eff_arcsec or cfg.fwhm_eff[band], cfg.pixel_scale_arcsec
+        )
         ce = central_pixel_electrons(src_mag, eph.ZPT_pe, frac)
-        if ce <= cfg.npe_pixel_saturate:
+        se = (eph.SKYSIG * eph.GAIN) ** 2  # sky electrons per pixel
+        max_e = max(ce, se)
+        if max_e <= cfg.npe_pixel_saturate:
+            if max_e >= cfg.npe_pixel_warn_nonlinear:
+                flags.add("warn_nonlinear")
             break
-        scale = max(0.1, cfg.npe_pixel_saturate / max(1.0, ce))
+        flags.add("sat_guard")
+        scale_src = (
+            cfg.npe_pixel_saturate / max(1.0, ce)
+            if ce > cfg.npe_pixel_saturate
+            else 1.0
+        )
+        scale_sky = (
+            cfg.npe_pixel_saturate / max(1.0, se)
+            if se > cfg.npe_pixel_saturate
+            else 1.0
+        )
+        scale = max(0.1, min(scale_src, scale_sky))
         t = max(min_exp_s, t * scale)
-    return t
+    else:
+        if max_e >= cfg.npe_pixel_warn_nonlinear:
+            flags.add("warn_nonlinear")
+    return t, flags

--- a/twilight_planner_pkg/scheduler.py
+++ b/twilight_planner_pkg/scheduler.py
@@ -4,68 +4,74 @@ This module batches targets by their first filter, routes within a batch using a
 filter-aware slew cost, and accounts for carousel overheads.  Cross-target
 filter swaps incur a one-time ``filter_change_s`` penalty, while additional
 filters within a visit add internal changes.  The allowed filter set per
-twilight window is governed by the Sun-altitude policy in
-``PlannerConfig.sun_alt_policy`` but can be overridden by the user.  Moon
+twilight window is strictly governed by the Sun-altitude policy in
+``PlannerConfig.sun_alt_policy``; filters outside the policy are never scheduled
+unless the user supplies a custom policy.  Moon
 separation constraints are evaluated in a shared AltAz frame and are ignored
 whenever the Moon is below the horizon.
 
 Overhead values follow Rubin Observatory technical notes (slew, readout, and
 filter change times), and airmass calculations use the Kasten & Young (1989)
-formula.
+formula.  Exposure times may be overridden by
+``PlannerConfig.sun_alt_exposure_ladder`` to shorten visits in bright
+twilight.
 """
 
 from __future__ import annotations
-from datetime import datetime, timezone, timedelta
+
+import warnings
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
-from typing import Dict, List, Tuple
-import pandas as pd
+from typing import Dict, List
+
+import astropy.units as u
 import numpy as np
+import pandas as pd
+from astropy.coordinates import AltAz, EarthLocation, SkyCoord, get_sun
+from astropy.time import Time
+
 try:
-    from tqdm.notebook import tqdm as _tqdm  # type: ignore
     import ipywidgets as _ipyw  # noqa: F401
+    from tqdm.notebook import tqdm as _tqdm  # type: ignore
+
     tqdm = _tqdm
 except Exception:  # pragma: no cover - fallback
     from tqdm.auto import tqdm
 
-import astropy.units as u
-from astropy.coordinates import SkyCoord, EarthLocation, AltAz, get_sun
-from astropy.time import Time
-import warnings
+from .astro_utils import (
+    _best_time_with_moon,
+    airmass_from_alt_deg,
+    allowed_filters_for_sun_alt,
+    choose_filters_with_cap,
+    great_circle_sep_deg,
+    parse_sn_type_to_window_days,
+    pick_first_filter_for_target,
+    slew_time_seconds,
+    twilight_windows_astro,
+)
+from .config import PlannerConfig
+from .constraints import effective_min_sep
+from .filter_policy import allowed_filters_for_window
+from .io_utils import extract_current_mags, standardize_columns
+from .photom_rubin import PhotomConfig, compute_epoch_photom
+from .priority import PriorityTracker
+from .simlib_writer import SimlibHeader, SimlibWriter
+from .sky_model import (
+    RubinSkyProvider,
+    SimpleSkyProvider,
+    SkyModelConfig,
+    sky_mag_arcsec2,
+)
 
 warnings.filterwarnings("ignore", message=".*get_moon.*deprecated.*")
 warnings.filterwarnings(
-    "ignore",
-    message=".*transforming other coordinates from <GCRS Frame.*>",
+    "ignore", message=".*transforming other coordinates from <GCRS Frame.*>"
 )
 warnings.filterwarnings(
     "ignore",
     message="Angular separation can depend on the direction of the transformation",
 )
 
-from .config import PlannerConfig
-from .io_utils import standardize_columns, extract_current_mags
-from .astro_utils import (
-    twilight_windows_astro,
-    great_circle_sep_deg,
-    choose_filters_with_cap,
-    per_sn_time_seconds,
-    parse_sn_type_to_window_days,
-    _best_time_with_moon,
-    airmass_from_alt_deg,
-    slew_time_seconds,
-    pick_first_filter_for_target,
-)
-from .priority import PriorityTracker
-from .simlib_writer import SimlibWriter, SimlibHeader
-from .filter_policy import allowed_filters_for_window
-from .constraints import effective_min_sep
-from .photom_rubin import PhotomConfig, compute_epoch_photom
-from .sky_model import (
-    SkyModelConfig,
-    sky_mag_arcsec2,
-    RubinSkyProvider,
-    SimpleSkyProvider,
-)
 
 def plan_twilight_range_with_caps(
     csv_path: str,
@@ -88,7 +94,8 @@ def plan_twilight_range_with_caps(
     end_date : str
         Inclusive end date in ``YYYY-MM-DD`` (UTC).
     cfg : PlannerConfig
-        Configuration with site, filter, and timing parameters.
+        Configuration with site, filter, and timing parameters. Filters outside
+        ``cfg.sun_alt_policy`` are excluded at disallowed Sun altitudes.
     verbose : bool, optional
         If ``True``, print progress messages.
 
@@ -114,6 +121,9 @@ def plan_twilight_range_with_caps(
         zpt_err_mag=cfg.zpt_err_mag,
         npe_pixel_saturate=cfg.simlib_npe_pixel_saturate,
     )
+    site = EarthLocation(
+        lat=cfg.lat_deg * u.deg, lon=cfg.lon_deg * u.deg, height=cfg.height_m * u.m
+    )
     sky_cfg = SkyModelConfig(
         dark_sky_mag=cfg.dark_sky_mag,
         twilight_delta_mag=cfg.twilight_delta_mag,
@@ -121,7 +131,7 @@ def plan_twilight_range_with_caps(
     try:
         sky_provider = RubinSkyProvider()
     except Exception:
-        sky_provider = SimpleSkyProvider(sky_cfg)
+        sky_provider = SimpleSkyProvider(sky_cfg, site=site)
     cfg.sky_provider = sky_provider
 
     writer = None
@@ -148,10 +158,8 @@ def plan_twilight_range_with_caps(
         filters.remove(drop)
         cfg.filters = filters
 
-
-    site = EarthLocation(lat=cfg.lat_deg*u.deg, lon=cfg.lon_deg*u.deg, height=cfg.height_m*u.m)
     start = pd.to_datetime(start_date, utc=True).date()
-    end   = pd.to_datetime(end_date,   utc=True).date()
+    end = pd.to_datetime(end_date, utc=True).date()
 
     pernight_rows: List[Dict] = []
     nights_rows: List[Dict] = []
@@ -172,7 +180,9 @@ def plan_twilight_range_with_caps(
         # Conservative baseline Moon separation used while sampling best times.
         # Detailed per-filter checks with altitude/phase scaling are applied later via effective_min_sep.
         vals: list[float] = []
-        if getattr(cfg, "min_moon_sep_by_filter", None) and getattr(cfg, "filters", None):
+        if getattr(cfg, "min_moon_sep_by_filter", None) and getattr(
+            cfg, "filters", None
+        ):
             try:
                 vals = [cfg.min_moon_sep_by_filter.get(f, 0.0) for f in cfg.filters]
             except Exception:
@@ -188,10 +198,18 @@ def plan_twilight_range_with_caps(
         if "typical_lifetime_days" in df.columns:
             lifetime_days_each = df["typical_lifetime_days"]
         else:
-            lifetime_days_each = df["SN_type_raw"].apply(lambda t: parse_sn_type_to_window_days(t, cfg))
-        min_allowed_disc_each = cutoff - lifetime_days_each.apply(lambda d: timedelta(days=int(d)))
+            lifetime_days_each = df["SN_type_raw"].apply(
+                lambda t: parse_sn_type_to_window_days(t, cfg)
+            )
+        min_allowed_disc_each = cutoff - lifetime_days_each.apply(
+            lambda d: timedelta(days=int(d))
+        )
         has_disc = df["discovery_datetime"].notna()
-        subset = df[has_disc & (df["discovery_datetime"] <= cutoff) & (df["discovery_datetime"] >= min_allowed_disc_each)].copy()
+        subset = df[
+            has_disc
+            & (df["discovery_datetime"] <= cutoff)
+            & (df["discovery_datetime"] >= min_allowed_disc_each)
+        ].copy()
         if subset.empty:
             if verbose:
                 print(f"{day.date().isoformat()}: 0 eligible")
@@ -199,12 +217,14 @@ def plan_twilight_range_with_caps(
 
         best_alts, best_times, best_winidx = [], [], []
         for _, row in subset.iterrows():
-            sc = SkyCoord(row["RA_deg"]*u.deg, row["Dec_deg"]*u.deg, frame="icrs")
+            sc = SkyCoord(row["RA_deg"] * u.deg, row["Dec_deg"] * u.deg, frame="icrs")
             max_alt, max_time, max_idx = -999.0, None, None
             best_moon = (float("nan"), float("nan"), float("nan"))
             for idx_w, w in enumerate(windows):
-                alt_deg, t_utc, moon_alt_deg, moon_phase, moon_sep_deg = _best_time_with_moon(
-                    sc, w, site, cfg.twilight_step_min, cfg.min_alt_deg, req_sep
+                alt_deg, t_utc, moon_alt_deg, moon_phase, moon_sep_deg = (
+                    _best_time_with_moon(
+                        sc, w, site, cfg.twilight_step_min, cfg.min_alt_deg, req_sep
+                    )
                 )
                 if alt_deg > max_alt:
                     max_alt, max_time, max_idx = alt_deg, t_utc, idx_w
@@ -220,16 +240,25 @@ def plan_twilight_range_with_caps(
         subset["best_time_utc"] = best_times
         subset["best_window_index"] = best_winidx
 
-        visible = subset[(subset["best_time_utc"].notna()) & (subset["max_alt_deg"] >= cfg.min_alt_deg) & (subset["best_window_index"] >= 0)].copy()
+        visible = subset[
+            (subset["best_time_utc"].notna())
+            & (subset["max_alt_deg"] >= cfg.min_alt_deg)
+            & (subset["best_window_index"] >= 0)
+        ].copy()
         if visible.empty:
             if verbose:
                 print(f"{day.date().isoformat()}: 0 visible")
             continue
 
         visible["priority_score"] = visible.apply(
-            lambda r: tracker.score(r["Name"], r.get("SN_type_raw"), cfg.priority_strategy), axis=1
+            lambda r: tracker.score(
+                r["Name"], r.get("SN_type_raw"), cfg.priority_strategy
+            ),
+            axis=1,
         )
-        visible.sort_values(["priority_score", "max_alt_deg"], ascending=[False, False], inplace=True)
+        visible.sort_values(
+            ["priority_score", "max_alt_deg"], ascending=[False, False], inplace=True
+        )
         top_global = visible.head(int(cfg.max_sn_per_night)).copy()
 
         for idx_w in sorted(set(top_global["best_window_index"].values)):
@@ -240,8 +269,21 @@ def plan_twilight_range_with_caps(
             win = windows[idx_w]
             mid = win[0] + (win[1] - win[0]) / 2
             sun_alt = (
-                get_sun(Time(mid)).transform_to(AltAz(location=site, obstime=Time(mid))).alt.to(u.deg).value
+                get_sun(Time(mid))
+                .transform_to(AltAz(location=site, obstime=Time(mid)))
+                .alt.to(u.deg)
+                .value
             )
+            # Apply exposure-time ladder: override baseline exposures if needed
+            original_exp = cfg.exposure_by_filter
+            override_exp: Dict[str, float] | None = None
+            for low, high, exp_dict in cfg.sun_alt_exposure_ladder:
+                if low < sun_alt <= high:
+                    override_exp = original_exp.copy()
+                    override_exp.update(exp_dict)
+                    cfg.exposure_by_filter = override_exp
+                    break
+
             candidates = []
             for _, row in group.iterrows():
                 allowed = allowed_filters_for_window(
@@ -254,9 +296,16 @@ def plan_twilight_range_with_caps(
                     cfg.fwhm_eff or 0.7,
                 )
                 allowed = [f for f in allowed if f in cfg.filters]
+                # Enforce sun_alt_policy: drop filters disallowed at this Sun altitude
+                allowed_policy = allowed_filters_for_sun_alt(sun_alt, cfg)
+                allowed = [f for f in allowed if f in allowed_policy]
                 moon_sep_ok = {
-                    f: row["_moon_sep"] >= effective_min_sep(
-                        f, row["_moon_alt"], row["_moon_phase"], cfg.min_moon_sep_by_filter
+                    f: row["_moon_sep"]
+                    >= effective_min_sep(
+                        f,
+                        row["_moon_alt"],
+                        row["_moon_phase"],
+                        cfg.min_moon_sep_by_filter,
                     )
                     for f in allowed
                 }
@@ -287,9 +336,15 @@ def plan_twilight_range_with_caps(
                 }
                 candidates.append(cand)
             if not candidates:
+                if override_exp is not None:
+                    cfg.exposure_by_filter = original_exp
                 continue
 
-            batch_order = [f for f in ["y", "z", "i", "r", "g", "u"] if any(c["first_filter"] == f for c in candidates)]
+            batch_order = [
+                f
+                for f in ["y", "z", "i", "r", "g", "u"]
+                if any(c["first_filter"] == f for c in candidates)
+            ]
 
             cap_s = window_caps.get(idx_w, 0.0)
             window_sum = 0.0
@@ -320,7 +375,16 @@ def plan_twilight_range_with_caps(
                             current_filter=state,
                         )
                         first_choices.append(first_tmp)
-                        sep = 0.0 if prev is None else great_circle_sep_deg(prev["RA_deg"], prev["Dec_deg"], t["RA_deg"], t["Dec_deg"])
+                        sep = (
+                            0.0
+                            if prev is None
+                            else great_circle_sep_deg(
+                                prev["RA_deg"],
+                                prev["Dec_deg"],
+                                t["RA_deg"],
+                                t["Dec_deg"],
+                            )
+                        )
                         cost = slew_time_seconds(
                             sep,
                             small_deg=cfg.slew_small_deg,
@@ -334,9 +398,20 @@ def plan_twilight_range_with_caps(
                     j = int(np.argmin(costs))
                     t = batch.pop(j)
                     first = first_choices.pop(j)
-                    sep = 0.0 if prev is None else great_circle_sep_deg(prev["RA_deg"], prev["Dec_deg"], t["RA_deg"], t["Dec_deg"])
+                    sep = (
+                        0.0
+                        if prev is None
+                        else great_circle_sep_deg(
+                            prev["RA_deg"], prev["Dec_deg"], t["RA_deg"], t["Dec_deg"]
+                        )
+                    )
                     cfg.current_mag_by_filter = mag_lookup.get(t["Name"])
                     cfg.current_alt_deg = t["max_alt_deg"]
+                    cfg.current_mjd = (
+                        Time(t["best_time_utc"]).mjd
+                        if isinstance(t["best_time_utc"], (datetime, pd.Timestamp))
+                        else None
+                    )
                     filters_pref = [first] + [x for x in t["allowed"] if x != first]
                     filters_used, timing = choose_filters_with_cap(
                         filters_pref,
@@ -353,7 +428,10 @@ def plan_twilight_range_with_caps(
 
                     epochs = []
                     for f in filters_used:
-                        exp_s = timing.get("exp_times", {}).get(f, cfg.exposure_by_filter.get(f, 0.0))
+                        exp_s = timing.get("exp_times", {}).get(
+                            f, cfg.exposure_by_filter.get(f, 0.0)
+                        )
+                        flags = timing.get("flags_by_filter", {}).get(f, set())
                         alt_deg = float(t["max_alt_deg"])
                         air = airmass_from_alt_deg(alt_deg)
                         mjd = (
@@ -363,7 +441,11 @@ def plan_twilight_range_with_caps(
                         )
                         if sky_provider:
                             sky_mag = sky_provider.sky_mag(
-                                mjd, t["RA_deg"], t["Dec_deg"], f, airmass_from_alt_deg(alt_deg)
+                                mjd,
+                                t["RA_deg"],
+                                t["Dec_deg"],
+                                f,
+                                airmass_from_alt_deg(alt_deg),
                             )
                         else:
                             sky_mag = sky_mag_arcsec2(f, sky_cfg)
@@ -385,13 +467,19 @@ def plan_twilight_range_with_caps(
                         pernight_rows.append(
                             {
                                 "date": day.date().isoformat(),
-                                "twilight_window": window_labels.get(idx_w, f"W{idx_w}"),
+                                "twilight_window": window_labels.get(
+                                    idx_w, f"W{idx_w}"
+                                ),
                                 "SN": t["Name"],
                                 "RA_deg": round(t["RA_deg"], 6),
                                 "Dec_deg": round(t["Dec_deg"], 6),
-                                "best_twilight_time_utc": pd.Timestamp(t["best_time_utc"]).tz_convert("UTC").isoformat()
-                                if isinstance(t["best_time_utc"], pd.Timestamp)
-                                else str(t["best_time_utc"]),
+                                "best_twilight_time_utc": (
+                                    pd.Timestamp(t["best_time_utc"])
+                                    .tz_convert("UTC")
+                                    .isoformat()
+                                    if isinstance(t["best_time_utc"], pd.Timestamp)
+                                    else str(t["best_time_utc"])
+                                ),
                                 "filter": f,
                                 "t_exp_s": round(exp_s, 1),
                                 "airmass": round(air, 3),
@@ -402,11 +490,16 @@ def plan_twilight_range_with_caps(
                                 "NEA_pix": round(eph.NEA_pix, 2),
                                 "RDNOISE": round(eph.RDNOISE, 2),
                                 "GAIN": round(eph.GAIN, 2),
-                                "saturation_guard_applied": exp_s < cfg.exposure_by_filter.get(f, exp_s) - 1e-6,
+                                "saturation_guard_applied": "sat_guard" in flags,
+                                "warn_nonlinear": "warn_nonlinear" in flags,
                                 "priority_score": round(float(t["priority_score"]), 2),
                                 "slew_s": round(timing["slew_s"], 2),
-                                "cross_filter_change_s": round(timing.get("cross_filter_change_s", 0.0), 2),
-                                "filter_changes_s": round(timing.get("filter_changes_s", 0.0), 2),
+                                "cross_filter_change_s": round(
+                                    timing.get("cross_filter_change_s", 0.0), 2
+                                ),
+                                "filter_changes_s": round(
+                                    timing.get("filter_changes_s", 0.0), 2
+                                ),
                                 "readout_s": round(timing["readout_s"], 2),
                                 "exposure_s": round(timing["exposure_s"], 2),
                                 "total_time_s": round(timing["total_s"], 2),
@@ -415,7 +508,11 @@ def plan_twilight_range_with_caps(
 
                     if writer and epochs:
                         writer.start_libid(
-                            libid_counter, t["RA_deg"], t["Dec_deg"], nobs=len(epochs), comment=t["Name"]
+                            libid_counter,
+                            t["RA_deg"],
+                            t["Dec_deg"],
+                            nobs=len(epochs),
+                            comment=t["Name"],
                         )
                         libid_counter += 1
                         for epoch in epochs:
@@ -432,33 +529,65 @@ def plan_twilight_range_with_caps(
                     window_slew_times.append(timing["slew_s"])
                     window_airmasses.append(air)
                     prev = t
-                    tracker.record_detection(t["Name"], timing["exposure_s"], filters_used)
+                    tracker.record_detection(
+                        t["Name"], timing["exposure_s"], filters_used
+                    )
 
             used_filters_csv = ",".join(sorted(filters_used_set))
-            nights_rows.append({
-                "date": day.date().isoformat(),
-                "twilight_window": window_labels.get(idx_w, f"W{idx_w}"),
-                "n_candidates": int(len(group)),
-                "n_planned": int(len([r for r in pernight_rows if (r['date']==day.date().isoformat() and r['twilight_window']==window_labels.get(idx_w, f'W{idx_w}'))])),
-                "sum_time_s": round(window_sum, 1),
-                "window_cap_s": int(cap_s),
-                "swap_count": int(swap_count_by_window.get(idx_w, 0)),
-                "internal_filter_changes": int(internal_changes),
-                "filter_change_s_total": round(window_filter_change_s, 1),
-                "mean_slew_s": float(np.mean(window_slew_times)) if window_slew_times else 0.0,
-                "median_airmass": float(np.median(window_airmasses)) if window_airmasses else 0.0,
-                "loaded_filters": ",".join(cfg.filters),
-                "filters_used_csv": used_filters_csv,
-            })
+            nights_rows.append(
+                {
+                    "date": day.date().isoformat(),
+                    "twilight_window": window_labels.get(idx_w, f"W{idx_w}"),
+                    "n_candidates": int(len(group)),
+                    "n_planned": int(
+                        len(
+                            [
+                                r
+                                for r in pernight_rows
+                                if (
+                                    r["date"] == day.date().isoformat()
+                                    and r["twilight_window"]
+                                    == window_labels.get(idx_w, f"W{idx_w}")
+                                )
+                            ]
+                        )
+                    ),
+                    "sum_time_s": round(window_sum, 1),
+                    "window_cap_s": int(cap_s),
+                    "swap_count": int(swap_count_by_window.get(idx_w, 0)),
+                    "internal_filter_changes": int(internal_changes),
+                    "filter_change_s_total": round(window_filter_change_s, 1),
+                    "mean_slew_s": (
+                        float(np.mean(window_slew_times)) if window_slew_times else 0.0
+                    ),
+                    "median_airmass": (
+                        float(np.median(window_airmasses)) if window_airmasses else 0.0
+                    ),
+                    "loaded_filters": ",".join(cfg.filters),
+                    "filters_used_csv": used_filters_csv,
+                }
+            )
+            if override_exp is not None:
+                cfg.exposure_by_filter = original_exp
 
         if verbose:
-            planned_today = [r for r in pernight_rows if r["date"] == day.date().isoformat()]
-            print(f"{day.date().isoformat()}: eligible={len(subset)} visible={len(visible)} planned_total={len(planned_today)}")
+            planned_today = [
+                r for r in pernight_rows if r["date"] == day.date().isoformat()
+            ]
+            print(
+                f"{day.date().isoformat()}: eligible={len(subset)} visible={len(visible)} planned_total={len(planned_today)}"
+            )
 
     pernight_df = pd.DataFrame(pernight_rows)
     nights_df = pd.DataFrame(nights_rows)
-    pernight_path = Path(outdir) / f"lsst_twilight_plan_{start.isoformat()}_to_{end.isoformat()}.csv"
-    nights_path   = Path(outdir) / f"lsst_twilight_summary_{start.isoformat()}_to_{end.isoformat()}.csv"
+    pernight_path = (
+        Path(outdir)
+        / f"lsst_twilight_plan_{start.isoformat()}_to_{end.isoformat()}.csv"
+    )
+    nights_path = (
+        Path(outdir)
+        / f"lsst_twilight_summary_{start.isoformat()}_to_{end.isoformat()}.csv"
+    )
     pernight_df.to_csv(pernight_path, index=False)
     nights_df.to_csv(nights_path, index=False)
     if writer:

--- a/twilight_planner_pkg/simlib_writer.py
+++ b/twilight_planner_pkg/simlib_writer.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 from dataclasses import dataclass
 from typing import Optional, TextIO
 
@@ -10,7 +11,7 @@ class SimlibHeader:
     SURVEY: str = "LSST_TWILIGHT"
     FILTERS: str = "ugrizY"
     PIXSIZE: float = 0.200
-    NPE_PIXEL_SATURATE: int = 90000
+    NPE_PIXEL_SATURATE: int = 100000
     PHOTFLAG_SATURATE: int = 2048
     PSF_UNIT: str = "NEA_PIXEL"
 

--- a/twilight_planner_pkg/sky_model.py
+++ b/twilight_planner_pkg/sky_model.py
@@ -1,6 +1,10 @@
 from __future__ import annotations
+
 from dataclasses import dataclass
 from typing import Optional, Protocol
+
+from astropy.coordinates import AltAz, EarthLocation, get_sun
+from astropy.time import Time
 
 
 @dataclass
@@ -14,32 +18,90 @@ class SkyModelConfig:
 
     def __post_init__(self):
         if self.dark_sky_mag is None:
-            self.dark_sky_mag = {"u":22.9, "g":22.2, "r":21.2, "i":20.5, "z":19.9, "y":18.9}
+            self.dark_sky_mag = {
+                "u": 22.9,
+                "g": 22.2,
+                "r": 21.2,
+                "i": 20.5,
+                "z": 19.9,
+                "y": 18.9,
+            }
 
 
-def sky_mag_arcsec2(band: str, cfg: SkyModelConfig) -> float:
-    """Return sky brightness for a band in mag/arcsec^2."""
+def sky_mag_arcsec2(
+    band: str, cfg: SkyModelConfig, sun_alt_deg: float | None = None
+) -> float:
+    """Return sky brightness for a band in mag/arcsec².
+
+    Parameters
+    ----------
+    band
+        Photometric band name (``"g"``, ``"r"``, ...).
+    cfg
+        Configuration controlling dark-sky reference magnitudes.
+    sun_alt_deg
+        Altitude of the Sun in degrees.  If provided the sky brightness is
+        brightened when the Sun is above astronomical twilight using a simple
+        linear model following Tyson & Gal (1993).  Negative values denote the
+        Sun below the horizon.  ``None`` falls back to the fixed
+        ``twilight_delta_mag`` offset used historically.
+
+    Returns
+    -------
+    float
+        Sky brightness in mag/arcsec².
+    """
 
     if cfg.use_override and cfg.override_mag is not None:
         return cfg.override_mag
-    return cfg.dark_sky_mag[band] - cfg.twilight_delta_mag
+
+    if sun_alt_deg is None:
+        return cfg.dark_sky_mag[band] - cfg.twilight_delta_mag
+
+    if sun_alt_deg <= -18.0:
+        return cfg.dark_sky_mag[band]
+
+    alt = min(sun_alt_deg, 0.0)
+    factors = {"g": 0.35, "r": 0.30, "i": 0.15, "z": 0.10, "y": 0.05}
+    penalty = (alt + 18.0) * factors.get(band, 0.2)
+    return cfg.dark_sky_mag[band] - penalty
 
 
 class SkyProvider(Protocol):
     """Protocol for sky-brightness providers."""
 
-    def sky_mag(self, mjd: float | None, ra_deg: float | None, dec_deg: float | None, band: str, airmass: float) -> float:
-        ...
+    def sky_mag(
+        self,
+        mjd: float | None,
+        ra_deg: float | None,
+        dec_deg: float | None,
+        band: str,
+        airmass: float,
+    ) -> float: ...
 
 
 class SimpleSkyProvider:
-    """Sky provider using the simple twilight-delta model."""
+    """Sky provider using :func:`sky_mag_arcsec2` with optional Sun altitude."""
 
-    def __init__(self, cfg: SkyModelConfig):
+    def __init__(self, cfg: SkyModelConfig, site: EarthLocation | None = None):
         self.cfg = cfg
+        self.site = site
 
-    def sky_mag(self, mjd: float | None, ra_deg: float | None, dec_deg: float | None, band: str, airmass: float) -> float:
-        return sky_mag_arcsec2(band, self.cfg)
+    def sky_mag(
+        self,
+        mjd: float | None,
+        ra_deg: float | None,
+        dec_deg: float | None,
+        band: str,
+        airmass: float,
+    ) -> float:
+        sun_alt_deg: float | None = None
+        if mjd is not None and self.site is not None:
+            t = Time(mjd, format="mjd", scale="utc")
+            sun_alt_deg = float(
+                get_sun(t).transform_to(AltAz(obstime=t, location=self.site)).alt.deg
+            )
+        return sky_mag_arcsec2(band, self.cfg, sun_alt_deg)
 
 
 class RubinSkyProvider:
@@ -50,5 +112,14 @@ class RubinSkyProvider:
 
         self.model = sb.SkyModel() if site is None else sb.SkyModel(site=site)
 
-    def sky_mag(self, mjd: float | None, ra_deg: float | None, dec_deg: float | None, band: str, airmass: float) -> float:
-        return float(self.model.return_mags({"filter": band, "airmass": airmass})["mag_sky"])
+    def sky_mag(
+        self,
+        mjd: float | None,
+        ra_deg: float | None,
+        dec_deg: float | None,
+        band: str,
+        airmass: float,
+    ) -> float:
+        return float(
+            self.model.return_mags({"filter": band, "airmass": airmass})["mag_sky"]
+        )

--- a/twilight_planner_pkg/tests/test_exptime_capping_sunalt.py
+++ b/twilight_planner_pkg/tests/test_exptime_capping_sunalt.py
@@ -1,0 +1,36 @@
+import astropy.units as u
+from astropy.coordinates import EarthLocation
+from astropy.time import Time
+
+from twilight_planner_pkg.astro_utils import compute_capped_exptime
+from twilight_planner_pkg.config import PlannerConfig
+from twilight_planner_pkg.sky_model import SimpleSkyProvider, SkyModelConfig
+
+
+def test_capping_is_stronger_when_sun_is_higher():
+    """Exposure capping should be more aggressive at brighter twilight."""
+
+    site = EarthLocation(lat=-30.2446 * u.deg, lon=-70.7494 * u.deg, height=2647 * u.m)
+    sky_cfg = SkyModelConfig()
+    provider = SimpleSkyProvider(sky_cfg, site=site)
+
+    cfg = PlannerConfig(
+        filters=["r"],
+        exposure_by_filter={"r": 15.0},
+        readout_s=0.0,
+        filter_change_s=0.0,
+    )
+    cfg.sky_provider = provider
+    cfg.current_mag_by_filter = {"r": 20.0}
+    cfg.current_alt_deg = 50.0
+
+    mjd_dark = Time("2025-01-05T08:00:00", scale="utc").mjd
+    mjd_bright = Time("2025-01-05T08:30:00", scale="utc").mjd
+
+    cfg.current_mjd = mjd_dark
+    t_dark, _ = compute_capped_exptime("r", cfg)
+
+    cfg.current_mjd = mjd_bright
+    t_bright, _ = compute_capped_exptime("r", cfg)
+
+    assert t_bright <= t_dark

--- a/twilight_planner_pkg/tests/test_photom_rubin.py
+++ b/twilight_planner_pkg/tests/test_photom_rubin.py
@@ -1,15 +1,36 @@
-from twilight_planner_pkg.photom_rubin import PhotomConfig, compute_epoch_photom, cap_exposure_for_saturation
+from twilight_planner_pkg.photom_rubin import (
+    PhotomConfig,
+    cap_exposure_for_saturation,
+    compute_epoch_photom,
+)
 
 
 def test_compute_epoch_photom_basics():
     cfg = PhotomConfig(gain_e_per_adu=1.6, npe_pixel_saturate=120000)
-    eph = compute_epoch_photom('r', 1.0, 60.0, 21.0, cfg)
+    eph = compute_epoch_photom("r", 1.0, 60.0, 21.0, cfg)
     assert abs(eph.ZPTAVG - 27.83) < 0.1
     assert eph.SKYSIG > 0
     assert eph.NEA_pix > 0
 
 
-def test_cap_exposure_for_saturation():
-    cfg = PhotomConfig(gain_e_per_adu=1.6, npe_pixel_saturate=120000)
-    t_new = cap_exposure_for_saturation('r', 5.0, 60.0, 14.0, 21.0, cfg)
+def test_cap_exposure_warns_and_caps_source():
+    cfg = PhotomConfig()
+    t_new, flags = cap_exposure_for_saturation("r", 5.0, 60.0, 14.0, 21.0, cfg)
     assert 0 < t_new < 5.0
+    assert "sat_guard" in flags
+    assert "warn_nonlinear" in flags
+
+
+def test_cap_exposure_warns_and_caps_sky():
+    cfg = PhotomConfig()
+    t_new, flags = cap_exposure_for_saturation("r", 15.0, 60.0, 25.0, 14.0, cfg)
+    assert 0 < t_new < 15.0
+    assert "sat_guard" in flags
+    assert "warn_nonlinear" in flags
+
+
+def test_cap_exposure_no_warn_no_cap():
+    cfg = PhotomConfig()
+    t_new, flags = cap_exposure_for_saturation("r", 5.0, 60.0, 20.0, 21.0, cfg)
+    assert t_new == 5.0
+    assert not flags

--- a/twilight_planner_pkg/tests/test_scheduler.py
+++ b/twilight_planner_pkg/tests/test_scheduler.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import datetime, timedelta, timezone
+from datetime import timedelta
 from pathlib import Path
 
 import pandas as pd
@@ -23,7 +23,9 @@ def test_plan_twilight_range_basic(tmp_path, monkeypatch):
 
     # ------------------------------------------------------------------
     # Prepare small deterministic input catalogue
-    data_path = Path(__file__).resolve().parents[2] / "data" / "ATLAS_2021_to25_cleaned.csv"
+    data_path = (
+        Path(__file__).resolve().parents[2] / "data" / "ATLAS_2021_to25_cleaned.csv"
+    )
     subset_csv = _make_subset_csv(data_path, tmp_path / "subset.csv", n=3)
 
     # ------------------------------------------------------------------
@@ -37,14 +39,18 @@ def test_plan_twilight_range_basic(tmp_path, monkeypatch):
         end_evening = date_utc.replace(hour=18, minute=30, second=0)
         return [(start_morning, end_morning), (start_evening, end_evening)]
 
-    def mock_best_time_with_moon(sc, window, loc, step_min, min_alt_deg, min_moon_sep_deg):
+    def mock_best_time_with_moon(
+        sc, window, loc, step_min, min_alt_deg, min_moon_sep_deg
+    ):
         start, _ = window
         return 50.0, start + timedelta(minutes=5), 0.0, 0.0, 180.0
 
     def mock_sep(ra1, dec1, ra2, dec2):
         return 0.0
 
-    monkeypatch.setattr(scheduler, "twilight_windows_astro", mock_twilight_windows_astro)
+    monkeypatch.setattr(
+        scheduler, "twilight_windows_astro", mock_twilight_windows_astro
+    )
     monkeypatch.setattr(scheduler, "_best_time_with_moon", mock_best_time_with_moon)
     monkeypatch.setattr(scheduler, "great_circle_sep_deg", mock_sep)
 
@@ -99,6 +105,7 @@ def test_plan_twilight_range_basic(tmp_path, monkeypatch):
         "RDNOISE",
         "GAIN",
         "saturation_guard_applied",
+        "warn_nonlinear",
         "priority_score",
     }
     assert expected_cols.issubset(pernight_df.columns)
@@ -107,8 +114,180 @@ def test_plan_twilight_range_basic(tmp_path, monkeypatch):
 
     # ------------------------------------------------------------------
     # nights_df checks
-    expected_night_cols = {"date", "twilight_window", "n_candidates", "n_planned", "sum_time_s", "window_cap_s"}
+    expected_night_cols = {
+        "date",
+        "twilight_window",
+        "n_candidates",
+        "n_planned",
+        "sum_time_s",
+        "window_cap_s",
+    }
     assert expected_night_cols.issubset(nights_df.columns)
     assert (nights_df["sum_time_s"] >= 0).all()
     assert (nights_df["sum_time_s"] <= nights_df["window_cap_s"]).all()
 
+
+def test_sun_alt_policy_enforced(tmp_path, monkeypatch):
+    """Filters outside the sun_alt_policy are never scheduled."""
+
+    data_path = (
+        Path(__file__).resolve().parents[2] / "data" / "ATLAS_2021_to25_cleaned.csv"
+    )
+    subset_csv = _make_subset_csv(data_path, tmp_path / "subset.csv", n=1)
+
+    from types import SimpleNamespace
+
+    import astropy.units as u
+
+    from twilight_planner_pkg import scheduler
+
+    def mock_twilight_windows_astro(date_utc, loc):
+        start_morning = date_utc.replace(hour=5, minute=0, second=0)
+        end_morning = date_utc.replace(hour=5, minute=30, second=0)
+        return [(start_morning, end_morning)]
+
+    def mock_best_time_with_moon(
+        sc, window, loc, step_min, min_alt_deg, min_moon_sep_deg
+    ):
+        start, _ = window
+        return 50.0, start + timedelta(minutes=5), 0.0, 0.0, 180.0
+
+    def mock_sep(ra1, dec1, ra2, dec2):
+        return 0.0
+
+    def mock_allowed_filters_for_window(*args, **kwargs):
+        return ["r", "i"]
+
+    def mock_get_sun(time):
+        return SimpleNamespace(
+            transform_to=lambda frame: SimpleNamespace(alt=-10 * u.deg)
+        )
+
+    monkeypatch.setattr(
+        scheduler, "twilight_windows_astro", mock_twilight_windows_astro
+    )
+    monkeypatch.setattr(scheduler, "_best_time_with_moon", mock_best_time_with_moon)
+    monkeypatch.setattr(scheduler, "great_circle_sep_deg", mock_sep)
+    monkeypatch.setattr(
+        scheduler, "allowed_filters_for_window", mock_allowed_filters_for_window
+    )
+    monkeypatch.setattr(scheduler, "get_sun", mock_get_sun)
+
+    cfg = PlannerConfig(
+        lat_deg=0.0,
+        lon_deg=0.0,
+        height_m=0.0,
+        filters=["r", "i"],
+        exposure_by_filter={"r": 10.0, "i": 10.0},
+        readout_s=1.0,
+        filter_change_s=1.0,
+        morning_cap_s=50.0,
+        evening_cap_s=50.0,
+        max_sn_per_night=1,
+        per_sn_cap_s=25.0,
+        min_moon_sep_by_filter={"r": 0.0, "i": 0.0},
+        require_single_time_for_all_filters=False,
+        min_alt_deg=0.0,
+        twilight_step_min=1,
+        allow_filter_changes_in_twilight=True,
+    )
+
+    start_date = end_date = "2025-07-30"
+
+    pernight_df, _ = plan_twilight_range_with_caps(
+        csv_path=str(subset_csv),
+        outdir=str(tmp_path),
+        start_date=start_date,
+        end_date=end_date,
+        cfg=cfg,
+        verbose=False,
+    )
+
+    assert set(pernight_df["filter"].unique()) == {"i"}
+
+
+def test_exposure_ladder_applied(tmp_path, monkeypatch):
+    """Exposure-time ladder overrides baseline exposures."""
+
+    data_path = (
+        Path(__file__).resolve().parents[2] / "data" / "ATLAS_2021_to25_cleaned.csv"
+    )
+    subset_csv = _make_subset_csv(data_path, tmp_path / "subset.csv", n=1)
+
+    from types import SimpleNamespace
+
+    import astropy.units as u
+
+    from twilight_planner_pkg import astro_utils, scheduler
+
+    def mock_twilight_windows_astro(date_utc, loc):
+        start = date_utc.replace(hour=5, minute=0, second=0)
+        end = date_utc.replace(hour=5, minute=30, second=0)
+        return [(start, end)]
+
+    def mock_best_time_with_moon(
+        sc, window, loc, step_min, min_alt_deg, min_moon_sep_deg
+    ):
+        start, _ = window
+        return 50.0, start + timedelta(minutes=5), 0.0, 0.0, 180.0
+
+    def mock_sep(ra1, dec1, ra2, dec2):
+        return 0.0
+
+    def mock_allowed_filters_for_window(*args, **kwargs):
+        return ["r"]
+
+    def mock_get_sun(time):
+        return SimpleNamespace(
+            transform_to=lambda frame: SimpleNamespace(alt=-10 * u.deg)
+        )
+
+    def mock_compute_capped_exptime(band, cfg):
+        return cfg.exposure_by_filter[band], set()
+
+    monkeypatch.setattr(
+        scheduler, "twilight_windows_astro", mock_twilight_windows_astro
+    )
+    monkeypatch.setattr(scheduler, "_best_time_with_moon", mock_best_time_with_moon)
+    monkeypatch.setattr(scheduler, "great_circle_sep_deg", mock_sep)
+    monkeypatch.setattr(
+        scheduler, "allowed_filters_for_window", mock_allowed_filters_for_window
+    )
+    monkeypatch.setattr(scheduler, "get_sun", mock_get_sun)
+    monkeypatch.setattr(
+        astro_utils, "compute_capped_exptime", mock_compute_capped_exptime
+    )
+
+    cfg = PlannerConfig(
+        lat_deg=0.0,
+        lon_deg=0.0,
+        height_m=0.0,
+        filters=["r"],
+        exposure_by_filter={"r": 15.0},
+        readout_s=0.0,
+        filter_change_s=0.0,
+        morning_cap_s=50.0,
+        evening_cap_s=50.0,
+        max_sn_per_night=1,
+        per_sn_cap_s=25.0,
+        min_moon_sep_by_filter={"r": 0.0},
+        require_single_time_for_all_filters=False,
+        min_alt_deg=0.0,
+        twilight_step_min=1,
+        allow_filter_changes_in_twilight=True,
+        sun_alt_exposure_ladder=[(-12.0, -8.0, {"r": 5.0})],
+        sun_alt_policy=[],
+    )
+
+    start_date = end_date = "2025-07-30"
+
+    pernight_df, _ = plan_twilight_range_with_caps(
+        csv_path=str(subset_csv),
+        outdir=str(tmp_path),
+        start_date=start_date,
+        end_date=end_date,
+        cfg=cfg,
+        verbose=False,
+    )
+
+    assert pernight_df["t_exp_s"].tolist() == [5.0]

--- a/twilight_planner_pkg/tests/test_sky_model.py
+++ b/twilight_planner_pkg/tests/test_sky_model.py
@@ -1,0 +1,36 @@
+import astropy.units as u
+import numpy as np
+from astropy.coordinates import AltAz, EarthLocation, get_sun
+from astropy.time import Time
+
+from twilight_planner_pkg.sky_model import (
+    SimpleSkyProvider,
+    SkyModelConfig,
+    sky_mag_arcsec2,
+)
+
+
+def test_sky_brightness_brightens_with_sun_alt():
+    cfg = SkyModelConfig()
+    dark = sky_mag_arcsec2("g", cfg, sun_alt_deg=-18.0)
+    mid = sky_mag_arcsec2("g", cfg, sun_alt_deg=-9.0)
+    assert mid < dark
+
+
+def test_fallback_without_sun_alt():
+    cfg = SkyModelConfig()
+    expected = cfg.dark_sky_mag["g"] - cfg.twilight_delta_mag
+    assert sky_mag_arcsec2("g", cfg, sun_alt_deg=None) == expected
+
+
+def test_simple_provider_uses_sun_altitude():
+    cfg = SkyModelConfig()
+    site = EarthLocation(
+        lat=-30.2446 * u.deg, lon=-70.7494 * u.deg, height=2647.0 * u.m
+    )
+    t = Time("2023-09-01T10:00:00", scale="utc")
+    sun_alt = get_sun(t).transform_to(AltAz(obstime=t, location=site)).alt.deg
+    provider = SimpleSkyProvider(cfg, site=site)
+    mag = provider.sky_mag(t.mjd, None, None, "g", 1.0)
+    expected = sky_mag_arcsec2("g", cfg, sun_alt_deg=float(sun_alt))
+    assert np.isclose(mag, expected)


### PR DESCRIPTION
- **Goal:** Improve twilight sky brightness estimates by modeling dependence on Sun altitude, prevent saturation from bright sky backgrounds, allow exposure-time ladder per Sun altitude, and unify pixel saturation handling with an 80 ke⁻ warning.
- **Plan Stage:** n/a
- **Changes:**
  - Added analytic twilight brightening model in `sky_mag_arcsec2` with per-band slopes.
  - `SimpleSkyProvider` now computes Sun altitude from location and MJD.
  - Scheduler initializes site before sky model and forwards it to `SimpleSkyProvider`.
  - Enforced `PlannerConfig.sun_alt_policy` as a hard filter constraint when selecting observations.
  - Capped exposure times when either source or sky background would saturate pixels, with warning flags for 80–100 ke⁻.
  - Introduced `sun_alt_exposure_ladder` to override baseline exposures in bright twilight with corresponding scheduler logic and tests.
  - Standardized saturation limits at 100 ke⁻ with an 80 ke⁻ non-linearity warning across planning and SIMLIB outputs.
  - Documented dynamic sky model, dual-threshold saturation guard, policy enforcement, and exposure ladder in `twilight_planner_pkg/README.md`.
  - Passed MJD through the scheduler so the Sun-altitude–aware sky model also governs exposure capping, with a regression test.
- **Assumptions & Units:** Sun altitude in degrees; sky brightness in mag/arcsec²; exposure times in seconds; pixel charges in e⁻.
- **Tests:** `ruff check twilight_planner_pkg/config.py twilight_planner_pkg/scheduler.py twilight_planner_pkg/astro_utils.py twilight_planner_pkg/tests/test_exptime_capping_sunalt.py`, `black --check twilight_planner_pkg/config.py twilight_planner_pkg/scheduler.py twilight_planner_pkg/astro_utils.py twilight_planner_pkg/tests/test_exptime_capping_sunalt.py`, `isort --profile black --check-only twilight_planner_pkg/config.py twilight_planner_pkg/scheduler.py twilight_planner_pkg/astro_utils.py twilight_planner_pkg/tests/test_exptime_capping_sunalt.py`, `mypy twilight_planner_pkg` (fails: missing stubs and type errors), `pytest -q`.
- **SIMLIB Impact:** Header and photometric calculations use a 100 ke⁻ saturation level; no structural changes to `S:` rows but new warnings are surfaced in planning outputs.
- **Risk & Rollback:** Revert commits to restore prior constant sky model and exposure handling.


------
https://chatgpt.com/codex/tasks/task_e_689c325c701c83219f838bc67530f838