### PR TITLE
Add README for twilight planner notebook

### DIFF
--- a/notebook/README.md
+++ b/notebook/README.md
@@ -1,0 +1,153 @@
+LSST Twilight Supernova Planner — Example Notebook README
+
+This README gives a concise, framework‑level view of how the twilight planner works and how the notebook parameters shape the behavior.
+
+⸻
+
+What this planner does
+
+Schedules supernova (SN) observations during astronomical twilight by combining:
+•Science constraints: target altitude, Moon separation (scaled by Moon altitude/phase), twilight sky brightness, typical post‑discovery visibility windows by SN type.
+•Engineering constraints: slew/settle time, readout, filter‑change overheads, carousel capacity, time caps per twilight window.
+•Strategy: priority scheme (hybrid “quick color → escalate” or LC depth), batching by first filter, and greedy routing to minimize combined slew + filter‑change cost.
+
+Outputs:
+•A per‑SN plan CSV (one row per scheduled visit).
+•A per‑night summary CSV (morning/evening window stats).
+•Optional SNANA SIMLIB file for simulations.
+
+⸻
+
+Main Steps & Logic
+
+1) Initialization & Data Ingest
+1.Prepare I/O & data
+Create the output directory; read the SN CSV; standardize column names (standardize_columns); derive current estimated magnitudes (extract_current_mags) used for filter feasibility and saturation guarding.
+2.Photometry config
+Build PhotomConfig (pixel scale, zeropoint for 1s, extinction coefficient, effective FWHM, read noise, gain, zeropoint error, pixel‑saturation threshold). These drive sky noise, NEA, and saturation checks.
+3.Observatory site
+Set EarthLocation to Cerro Pachón (Rubin Observatory): latitude −30.2446°, longitude −70.7494°, height 2663 m.
+4.Sky brightness model
+Try RubinSkyProvider (Sun‑altitude aware); if unavailable, fall back to SimpleSkyProvider (configured by dark‑sky mag and a twilight brightening offset).
+5.SIMLIB (optional)
+If cfg.simlib_out is set, write the SIMLIB header and prepare to append per‑epoch entries (MJD, band, GAIN, RDNOISE, SKYSIG, NEA, zeropoint, etc.).
+6.Carousel capacity check
+If the requested cfg.filters exceeds cfg.carousel_capacity (here 5), drop one filter (by rule; typically u or the last) and warn. The rest of scheduling only considers the loaded filters.
+
+⸻
+
+2) Night‑by‑Night Loop
+
+For each UTC date in START_DATE … END_DATE:
+1.Find astronomical twilight windows
+Compute morning/evening intervals where the Sun altitude satisfies −18° < alt < 0° (twilight_windows_astro).
+2.Set a conservative Moon‑separation guard
+For finding best times, use the max of MIN_MOON_SEP_BY_FILTER over loaded filters as a baseline; automatically ignore the constraint when the Moon is below the horizon.
+3.Initialize window state
+For each window: current loaded filter (start with START_FILTER), filter‑swap counters, and time caps (MORNING_CAP_S / EVENING_CAP_S).
+4.Filter eligible SNe by “lifetime”
+Using discovery time and TYPICAL_DAYS_BY_TYPE (with a 1.2× safety factor via parse_sn_type_to_window_days), accept only SNe still in their typical observability window on this date.
+5.Best time per SN (Moon‑aware)
+For each candidate, sample the two twilight windows at TWILIGHT_STEP_MIN minutes (here 2 min); call _best_time_with_moon to get the maximum altitude time that also honors Moon separation (scaled by Moon altitude/phase). Keep the better of the two windows.
+6.Visible SN filter
+Keep targets with a valid best time, max altitude ≥ MIN_ALT_DEG (here 20°), and a valid window index.
+7.Priorities & global selection
+Score with PriorityTracker (hybrid or LC). Sort by priority, then max altitude (descending) and take the top MAX_SN_PER_NIGHT (here 10) as the nightly candidate pool (still subject to per‑window caps later).
+
+⸻
+
+3) Scheduling Within Each Twilight Window
+
+For each window index idx_w present that night:
+1.Sun‑altitude exposure ladder (optional)
+Compute the window mid‑time Sun altitude. If cfg.sun_alt_exposure_ladder is defined, temporarily override cfg.exposure_by_filter to shorten exposures at brighter twilight.
+2.Build candidates per target
+For each SN in this window:
+•Use allowed_filters_for_window(...) to get physically allowed filters combining current mag, Sun altitude, Moon geometry, airmass, seeing.
+•Intersect with user‑requested FILTERS.
+•Enforce Sun‑alt policy via allowed_filters_for_sun_alt(sun_alt, cfg) (strict: anything outside policy is dropped).
+•For each allowed filter, check Moon separation with effective_min_sep (dynamic with Moon altitude/phase).
+•Choose the first filter for this target via pick_first_filter_for_target(...), which accounts for priority stage, Moon OK flags, current carousel state, and (if available) the target’s current magnitudes. Discard the target if none qualifies.
+3.Batch by first filter
+Group targets by their chosen first filter. Execute batches in the order y → z → i → r → g → u (redder first to cope with brightening twilight).
+4.Greedy routing with time‑packing under the window cap
+•Maintain window_sum, previous target prev, and current loaded filter state.
+•Within each batch, repeatedly pick the next target by minimizing:
+slew time to it (slew_time_seconds from great‑circle separation) + a one‑time cross‑target filter‑change penalty if its first filter ≠ state.
+(This “cost” is for ordering only; the booked time comes from the next step.)
+•For the chosen target:
+•Set cfg.current_mag_by_filter, cfg.current_alt_deg, cfg.current_mjd (context for saturation guard).
+•Build the visit’s filter list: [first] + other allowed (de‑duplicated).
+•Call choose_filters_with_cap(...) to select a subset that fits PER_SN_CAP_S (here 120 s) and return a full timing breakdown: slew, readout, exposure, cross‑target and internal filter‑change times, plus any saturation/non‑linearity flags (if capped exposures are used).
+•If adding this visit would exceed the window cap (MORNING_CAP_S/EVENING_CAP_S, each 600 s here), skip it; otherwise:
+•Accumulate the booked time; update total filter‑change seconds for reporting.
+•For each filter used, compute sky brightness (Rubin or fallback model) and photometric products (compute_epoch_photom: zeropoint, SKYSIG, NEA, RDNOISE, GAIN).
+•Append a per‑SN row with times/conditions/flags/priority.
+•If SIMLIB is enabled, write EPOCHs (MJD, band, GAIN, RDNOISE, SKYSIG, NEA, ZP, etc.).
+•Update state to the last used filter, bump internal filter‑change counters, set prev = target, and record the detection/exposure to PriorityTracker (used for cross‑night strategy).
+5.Window summary row
+After finishing a window, write a per‑window summary: number of candidates vs. planned, total time vs. cap, filter‑swap counts, average slew time, median airmass, requested vs. actually used filters, etc.
+6.Restore exposures if overridden
+If an exposure ladder was applied for this window, revert to the original cfg.exposure_by_filter.
+
+⸻
+
+4) Outputs
+•Per‑SN CSV: lsst_twilight_plan_<start>_to_<end>.csv
+One row per scheduled visit with date, window, best time, filter, t_exp_s, airmass/altitude, sky brightness, photometric terms (ZPT, SKYSIG, NEA, RDNOISE, GAIN), saturation/non‑linear flags, priority, and time breakdown (slew/readout/exposure/filter changes/total).
+•Per‑night summary CSV: lsst_twilight_summary_<start>_to_<end>.csv
+One row per window: candidate/planned counts, time usage vs. cap, swap counts, internal filter changes, mean slew, median airmass, loaded filters, actually used filters.
+•SIMLIB (optional): if SIMLIB_OUT is set, a SNANA‑compatible library with all EPOCHs is produced.
+
+⸻
+
+Notebook Parameter Highlights (and why these defaults)
+•Date Range (UTC):
+START_DATE="2024-01-01", END_DATE="2024-01-03" — a short window for quick iteration and validation.
+•Site:
+LAT_DEG=-30.2446, LON_DEG=-70.7494, HEIGHT_M=2663 — Rubin site; required for correct twilight and airmass calculations.
+•Visibility:
+MIN_ALT_DEG=20.0 — avoids the worst airmass while keeping more sky accessible in twilight.
+•Filters & Hardware:
+FILTERS=["g","r","i","z"], CAROUSEL_CAPACITY=5 — Rubin carousel holds up to five; u/y are not loaded in this example.
+EXPOSURE_BY_FILTER=5s — very short exposures to mitigate twilight brightness and saturation risk.
+MAX_FILTERS_PER_VISIT=1 — one filter per visit reduces swaps and keeps within PER_SN_CAP_S.
+START_FILTER="g" — initial carousel state only; the plan adapts per target.
+•Sun‑Altitude Policy:
+
+(-18,-15): ["y","z","i"]
+(-15,-12): ["z","i","r"]
+(-12,  0): ["i","z","y"]
+
+Only filters allowed by policy and present in FILTERS are considered (policy entries for unloaded bands like y are safely ignored).
+
+•Slew Model:
+SLEW_SMALL_DEG=3.5, SLEW_SMALL_TIME_S=4.0, SLEW_RATE_DEG_PER_S=5.25, SLEW_SETTLE_S=1.0 — a simple, piecewise model with a constant small‑slew time and a linear rate for larger moves.
+•Moon:
+MIN_MOON_SEP_BY_FILTER={"g":50,"r":35,"i":30,"z":25, ...} — tighter in blue to protect S/N; dynamically scaled by Moon altitude/phase; ignored when Moon is set.
+REQUIRE_SINGLE_TIME_FOR_ALL=True — enforces a single “best time” per visit (if your build uses it), ensuring all filters (if >1) share the same epoch in a visit.
+•Time Caps:
+PER_SN_CAP_S=120 — bounds per‑SN work (slew + readout + exposure + filter changes).
+MORNING_CAP_S=600, EVENING_CAP_S=600 — roughly 10 minutes each; ensures plans pack into tight twilight windows.
+TWILIGHT_STEP_MIN=2 — few‑minute sampling captures altitude/Moon geometry changes without over‑sampling.
+MAX_SN_PER_NIGHT=10 — global nightly cap before window‑level packing.
+•Priority Strategy:
+PRIORITY_STRATEGY="hybrid" with HYBRID_DETECTIONS=2, HYBRID_EXPOSURE=300s, LC_DETECTIONS=5, LC_EXPOSURE=300s.
+Starts broad with quick detections; escalates to deeper coverage for promising SNe.
+•Photometry / Sky:
+PIXEL_SCALE_ARCSEC=0.2, READ_NOISE_E=5, GAIN_E_PER_ADU=1, ZPT_ERR_MAG=0.01.
+TWILIGHT_DELTA_MAG=2.5 if the fallback sky model is used (Rubin provider preferred).
+•SIMLIB:
+SIMLIB_OUT=None (disabled in the example). Set e.g. "twilight.simlib" to generate a SIMLIB.
+•Misc:
+TYPICAL_DAYS_BY_TYPE (e.g., Ia: 70, II‑P: 100, …) and DEFAULT_TYPICAL_DAYS=60 define the baseline lifetime window (inflated by 1.2× for safety).
+ALLOW_FILTER_CHANGES_IN_TWILIGHT=False: the example already constrains visits via MAX_FILTERS_PER_VISIT=1; if your build of the planner honors this flag, it further discourages cross‑target swaps in twilight.
+
+⸻
+
+Practical Tips
+•Short exposures + single‑filter visits are deliberate: twilight is bright and short; you’ll get more distinct SNe with fewer swaps.
+•The Sun‑altitude policy is strict: even if a filter is loaded, it won’t be used when the Sun is too high for that band.
+•If you want multi‑filter color on the same visit, increase MAX_FILTERS_PER_VISIT and be prepared to raise PER_SN_CAP_S and the window caps—or add a Sun‑alt exposure ladder so exposures shrink as the Sun rises.
+
+⸻


### PR DESCRIPTION
## Goal
- Document example LSST twilight supernova planner notebook

## Plan Stage
- N/A

## Changes
- add notebook/README.md describing planner workflow, outputs, parameters, and tips
- remove instruction to paste README section into notebook

## Assumptions & Units
- none

## Tests
- `ruff check .` *(fails: E401 and other issues)*
- `black --check .` *(fails: would reformat files)*
- `isort --check-only .` *(fails: imports not sorted)*
- `mypy twilight_planner_pkg` *(fails: multiple type errors and missing stubs)*
- `pytest -q`

## SIMLIB Impact
- none

## Risk & Rollback
- low; revert notebook/README.md to remove documentation


------
https://chatgpt.com/codex/tasks/task_e_689c62c209a0832180e6ddee21128287