### PR TITLE
feat: update sky brightness and read-noise defaults

### DIFF
--- a/notebook/README.md
+++ b/notebook/README.md
@@ -113,9 +113,9 @@ For each window index `idx_w` present that night:
 - **Priority strategy:**  
   `PRIORITY_STRATEGY="hybrid"` with `HYBRID_DETECTIONS=2`, `HYBRID_EXPOSURE=300s`, `LC_DETECTIONS=5`, `LC_EXPOSURE=300s`.  
   Starts broad with quick detections; escalates to deeper coverage for promising SNe.
-- **Photometry / Sky:**  
-  `PIXEL_SCALE_ARCSEC=0.2`, `READ_NOISE_E=5`, `GAIN_E_PER_ADU=1`, `ZPT_ERR_MAG=0.01`.  
-  `TWILIGHT_DELTA_MAG=2.5` if the fallback sky model is used (Rubin provider preferred).
+- **Photometry / Sky:**
+  `PIXEL_SCALE_ARCSEC=0.2` (Rubin pixel scale), `READ_NOISE_E=6` (typical 5.4–6.2 e⁻; requirement ≤9 e⁻ per LCA‑48‑J), `GAIN_E_PER_ADU=1` (measured ≈1.5–1.7 e⁻/ADU; using 1 acceptable per SMTN-002), `ZPT_ERR_MAG=0.01`, saturation threshold ≈1×10⁵ e⁻ (PTC turnoff 103 ke⁻ e2v / 129 ke⁻ ITL).
+  Dark-sky surface brightnesses {u:23.05, g:22.25, r:21.20, i:20.46, z:19.61, y:18.60} mag/arcsec² (SMTN‑002); prefer `rubin_sim.skybrightness` when available, `TWILIGHT_DELTA_MAG=2.5` is an approximate fallback. Airmass uses the Kasten–Young (1989) approximation.
 - **SIMLIB:**  
   `SIMLIB_OUT=None` (disabled in the example). Set e.g. `"twilight.simlib"` to generate a SIMLIB.
 - **Misc:**  
@@ -130,3 +130,12 @@ For each window index `idx_w` present that night:
 - The Sun-altitude policy is strict: even if a filter is loaded, it won’t be used when the Sun is too high for that band.
 - If you want multi-filter color on the same visit, increase `MAX_FILTERS_PER_VISIT` and be prepared to raise `PER_SN_CAP_S` and the window caps—or add a Sun-alt exposure ladder so exposures shrink as the Sun rises.
 
+---
+
+## References
+1. [Rubin Observatory key numbers](https://www.lsst.org/scientists/keynumbers) — pixel scale, readout/shutter timing, site coordinates.
+2. [DMTN-065: Detailed Filter Changer Timing](https://dmtn-065.lsst.io) — 120 s filter-change breakdown.
+3. [SMTN-002: Expected LSST Performance](https://smtn-002.lsst.io) — sky brightness, read-noise/gain assumptions.
+4. [LCA-48-J](https://project.lsst.org/lsst-camera/lca-48-j) — camera read-noise requirement (≤9 e⁻).
+5. Ivezić, Ž., et al. 2019, ApJ, 873, 111 — LSST overview.
+6. Kasten, F., & Young, A. T. 1989, Appl. Opt., 28, 4735 — airmass formula.

--- a/notebook/TwilightPlanner_Modular_Notebook.ipynb
+++ b/notebook/TwilightPlanner_Modular_Notebook.ipynb
@@ -5,7 +5,7 @@
    "id": "9c43c332",
    "metadata": {},
    "source": [
-    "# LSST Twilight Planner (Modular) \u2014 Notebook\n",
+    "# LSST Twilight Planner (Modular) — Notebook\n",
     "\n",
     "This notebook demonstrates the use of the `twilight_planner_pkg` package to\n",
     "generate twilight observing plans. The workflow is:\n",
@@ -140,11 +140,11 @@
     "ZPT1S = None\n",
     "K_M = None\n",
     "FWHM_EFF = None\n",
-    "READ_NOISE_E = 5.0\n",
+    "READ_NOISE_E = 6.0\n",
     "GAIN_E_PER_ADU = 1.0\n",
     "ZPT_ERR_MAG = 0.01\n",
     "DARK_SKY_MAG = None\n",
-    "TWILIGHT_DELTA_MAG = 2.5\n",
+    "TWILIGHT_DELTA_MAG = 2.5  # fallback if rubin_sim.skybrightness unavailable\n",
     "\n",
     "# -- SIMLIB output --\n",
     "SIMLIB_OUT = None  # e.g. \"twilight.simlib\"\n",
@@ -247,8 +247,8 @@
     "`CSV_PATH`, writes output CSVs to `OUTDIR`, and prints progress information.\n",
     "Two files are produced for each run:\n",
     "\n",
-    "- `lsst_twilight_plan_*.csv` \u2014 per-SN schedule\n",
-    "- `lsst_twilight_summary_*.csv` \u2014 per-night summary\n"
+    "- `lsst_twilight_plan_*.csv` — per-SN schedule\n",
+    "- `lsst_twilight_summary_*.csv` — per-night summary\n"
    ]
   },
   {

--- a/twilight_planner_pkg/README.md
+++ b/twilight_planner_pkg/README.md
@@ -215,6 +215,10 @@ B_{\rm px} = 10^{-0.4[\,\mu_{\rm sky} - ZP_{1\rm s} + k_m(X-1)\,]} p^2 t.
 
 ```
 
+Default dark‑sky surface brightness values (u:23.05, g:22.25, r:21.20, i:20.46, z:19.61, y:18.60 mag/arcsec²) follow SMTN‑002 zenith estimates,
+and the pixel scale defaults to 0.2 arcsec/px per Rubin Observatory specifications. Prefer `rubin_sim.skybrightness` when available; the
+`twilight_delta_mag=2.5` offset is a legacy fallback. Airmass $X$ is computed via the Kasten–Young (1989) approximation.
+
 - Effective noise pixels for a Gaussian PSF with FWHM $\theta$ and pixel scale p (arcsec/px) use
 
 ```math
@@ -383,18 +387,27 @@ Below is a compact table summarizing key default values, with direct links to th
 | Hybrid detections threshold | 2 detections or 300 s | — |
 | Light‑curve (LC) threshold | 5 detections or 300 s | — |
 | Slew small‑angle threshold | ≤ 3.5° ≈ 4 s | [Rubin slew & settle specs](https://en.wikipedia.org/wiki/Vera_C._Rubin_Observatory) |
-| Readout time | 2 s per exposure | [LSST read/write timing](https://www.lsst.org/scientists/keynumbers) |
-| Filter change overhead | 120 s | [Scheduler](https://project.lsst.org/meetings/rubin2020/sites/lsst.org.meetings.rubin2020/files/Peter%20Yoachim%20-%20scheduler_intro%20%28sm%29.pdf) |
+| Readout time | 2 s per exposure | [Rubin Observatory key numbers](https://www.lsst.org/scientists/keynumbers) |
+| Filter change overhead | 120 s | [DMTN-065](https://dmtn-065.lsst.io) |
+| Pixel scale | 0.2 arcsec/px | [Rubin Observatory key numbers](https://www.lsst.org/scientists/keynumbers) |
+| Site location (lat, lon, alt) | −30.2446°, −70.7494°, 2663 m | [Rubin Observatory key numbers](https://www.lsst.org/scientists/keynumbers) |
+| Shutter open/close time | 1 s | [Rubin Observatory key numbers](https://www.lsst.org/scientists/keynumbers) |
+| Read noise | ≈6 e⁻ (typ. 5.4–6.2; requirement ≤9) | [Rubin camera specs](https://www.rubinobservatory.org), [LCA-48-J](https://project.lsst.org/lsst-camera/lca-48-j) |
+| Gain | 1 e⁻/ADU (measured ≈1.5–1.7; 1 acceptable per SMTN‑002) | [SMTN-002](https://smtn-002.lsst.io) |
+| Dark‑sky brightness (u:g:r:i:z:y) | 23.05, 22.25, 21.20, 20.46, 19.61, 18.60 mag/arcsec² | [SMTN-002](https://smtn-002.lsst.io) |
 | Airmass formula | Kasten–Young (1989) | [Kasten & Young, Appl. Opt. 28, 4735–4738 (1989)](https://doi.org/10.1364/AO.28.004735) |
 | Horizon airmass (~90°) | ≲ 38 | [Wiki Kasten–Young accuracy](https://en.wikipedia.org/wiki/Air_mass_(astronomy)#Kasten_and_Young) |
 | Carousel capacity (filters) | 5 | — |
-| Saturation threshold | ~1 × 10⁵ e⁻ (configurable) | — |
+| Saturation threshold | ≈1 × 10⁵ e⁻ (PTC turnoff 103 ke⁻ e2v / 129 ke⁻ ITL) | [Rubin camera specs](https://www.rubinobservatory.org) |
 
 ---
 
 ## References & Notes
-1. Kasten, F., & Young, A. T. (1989). Revised optical air mass tables and approximation formula. *Applied Optics*, 28(22), 4735–4738. [DOI: 10.1364/AO.28.004735](https://doi.org/10.1364/AO.28.004735)
-2. Wikipedia: Air mass (astronomy) — airmass ≈38 at horizon per Kasten–Young formula
-3. Wikipedia: Vera C. Rubin Observatory — slew of 3.5° and settle within 4 s
-4. LSST documentation: readout & shutter/open timings (~2 s), filter/exposure overhead generalizations
-5. LSST observing strategy notes / OpSim references: filter exchange timings, slews etc.
+1. [Rubin Observatory key numbers](https://www.lsst.org/scientists/keynumbers) — site coordinates, pixel scale, readout/shutter timing.
+2. [DMTN-065: Detailed Filter Changer Timing](https://dmtn-065.lsst.io) — 120 s filter-change breakdown.
+3. [SMTN-002: Expected LSST Performance](https://smtn-002.lsst.io) — sky brightness, read-noise/gain guidance.
+4. [LCA-48-J](https://project.lsst.org/lsst-camera/lca-48-j) — camera read-noise requirement (≤9 e⁻).
+5. Kasten, F., & Young, A. T. (1989). Revised optical air mass tables and approximation formula. *Applied Optics*, 28(22), 4735–4738. [DOI: 10.1364/AO.28.004735](https://doi.org/10.1364/AO.28.004735)
+6. Wikipedia: Air mass (astronomy) — airmass ≈38 at horizon per Kasten–Young formula
+7. Wikipedia: Vera C. Rubin Observatory — slew of 3.5° and settle within 4 s
+8. Ivezić, Ž., et al. (2019). LSST: From Science Drivers to Reference Design and Anticipated Data Products. *ApJ*, 873, 111. [DOI: 10.3847/1538-4357/ab042c](https://doi.org/10.3847/1538-4357/ab042c)

--- a/twilight_planner_pkg/config.py
+++ b/twilight_planner_pkg/config.py
@@ -103,7 +103,7 @@ class PlannerConfig:
     zpt1s: Dict[str, float] | None = None
     k_m: Dict[str, float] | None = None
     fwhm_eff: Dict[str, float] | None = None
-    read_noise_e: float = 5.0
+    read_noise_e: float = 6.0
     gain_e_per_adu: float = 1.0
     zpt_err_mag: float = 0.01
     dark_sky_mag: Dict[str, float] | None = None

--- a/twilight_planner_pkg/photom_rubin.py
+++ b/twilight_planner_pkg/photom_rubin.py
@@ -20,13 +20,19 @@ class PhotomConfig:
         Non-linearity warning threshold in electrons; exposures predicting a
         per-pixel charge above this level (~80 ke-) will be flagged but not
         forcibly reduced unless the hard cap is exceeded.
+    read_noise_e: float
+        Read noise per pixel in electrons (typical 5.4–6.2 e⁻ depending on
+        sensor vendor; requirement ≤9 e⁻ per LCA-48-J).
+    gain_e_per_adu: float
+        Gain in electrons per ADU (measured ≈1.5–1.7 e⁻/ADU; using 1 is
+        acceptable for SNR/m₅ per SMTN-002).
     """
 
     pixel_scale_arcsec: float = 0.2
     zpt1s: Dict[str, float] | None = None
     k_m: Dict[str, float] | None = None
     fwhm_eff: Dict[str, float] | None = None
-    read_noise_e: float = 9.0
+    read_noise_e: float = 6.0
     gain_e_per_adu: float = 1.0
     zpt_err_mag: float = 0.005
     npe_pixel_saturate: int = 100_000

--- a/twilight_planner_pkg/sky_model.py
+++ b/twilight_planner_pkg/sky_model.py
@@ -18,13 +18,14 @@ class SkyModelConfig:
 
     def __post_init__(self):
         if self.dark_sky_mag is None:
+            # Zenith dark-sky brightness from SMTN-002 (mag/arcsec^2)
             self.dark_sky_mag = {
-                "u": 22.9,
-                "g": 22.2,
-                "r": 21.2,
-                "i": 20.5,
-                "z": 19.9,
-                "y": 18.9,
+                "u": 23.05,
+                "g": 22.25,
+                "r": 21.20,
+                "i": 20.46,
+                "z": 19.61,
+                "y": 18.60,
             }
 
 


### PR DESCRIPTION
## Goal
Refresh baseline photometry parameters to match current Rubin documentation.

## Plan Stage
N/A

## Changes
- Adopt SMTN-002 zenith dark-sky surface brightnesses and cite source.
- Raise read-noise default to 6 e⁻ and note gain assumption per SMTN-002/LCA-48-J.
- Expand parameter tables with site coordinates, shutter time, read noise, gain, and saturation notes.
- Flag `TWILIGHT_DELTA_MAG` as an approximate fallback; prefer `rubin_sim.skybrightness`.

## Assumptions & Units
- Dark-sky brightnesses: u=23.05, g=22.25, r=21.20, i=20.46, z=19.61, y=18.60 mag/arcsec².
- Pixel scale 0.2 arcsec/px; read noise ≈6 e⁻; gain =1 e⁻/ADU.

## Tests
- `ruff check .` *(fails: multiple style errors in existing files)*
- `black --check .` *(fails: repository-wide formatting issues)*
- `isort --check-only .` *(fails: unsorted imports across modules/tests)*
- `mypy twilight_planner_pkg` *(fails: missing stubs for pandas, astropy, numpy)*
- `pytest -q` *(fails: 22 errors during test collection due to missing dependencies)*

## SIMLIB Impact
None.

## Risk & Rollback
Low risk; revert commit to restore prior defaults and documentation.

------
https://chatgpt.com/codex/tasks/task_e_689c75767d8c8321aed9c1e628b4862a