### PR TITLE
Classify and label twilight windows

### DIFF
--- a/twilight_planner_pkg/tests/test_scheduler.py
+++ b/twilight_planner_pkg/tests/test_scheduler.py
@@ -37,7 +37,10 @@ def test_plan_twilight_range_basic(tmp_path, monkeypatch):
         end_morning = date_utc.replace(hour=5, minute=30, second=0)
         start_evening = date_utc.replace(hour=18, minute=0, second=0)
         end_evening = date_utc.replace(hour=18, minute=30, second=0)
-        return [(start_morning, end_morning), (start_evening, end_evening)]
+        return [
+            {"start": start_morning, "end": end_morning, "label": "morning"},
+            {"start": start_evening, "end": end_evening, "label": "evening"},
+        ]
 
     def mock_best_time_with_moon(
         sc, window, loc, step_min, min_alt_deg, min_moon_sep_deg
@@ -144,7 +147,7 @@ def test_sun_alt_policy_enforced(tmp_path, monkeypatch):
     def mock_twilight_windows_astro(date_utc, loc):
         start_morning = date_utc.replace(hour=5, minute=0, second=0)
         end_morning = date_utc.replace(hour=5, minute=30, second=0)
-        return [(start_morning, end_morning)]
+        return [{"start": start_morning, "end": end_morning, "label": "morning"}]
 
     def mock_best_time_with_moon(
         sc, window, loc, step_min, min_alt_deg, min_moon_sep_deg
@@ -223,7 +226,7 @@ def test_exposure_ladder_applied(tmp_path, monkeypatch):
     def mock_twilight_windows_astro(date_utc, loc):
         start = date_utc.replace(hour=5, minute=0, second=0)
         end = date_utc.replace(hour=5, minute=30, second=0)
-        return [(start, end)]
+        return [{"start": start, "end": end, "label": "morning"}]
 
     def mock_best_time_with_moon(
         sc, window, loc, step_min, min_alt_deg, min_moon_sep_deg

--- a/twilight_planner_pkg/tests/test_twilight_labeling.py
+++ b/twilight_planner_pkg/tests/test_twilight_labeling.py
@@ -1,0 +1,35 @@
+from datetime import datetime, time, timedelta, timezone
+
+import astropy.units as u
+from astropy.coordinates import EarthLocation
+
+from twilight_planner_pkg.astro_utils import twilight_windows_astro
+
+LOC = EarthLocation(lat=-30.1652778 * u.deg, lon=-70.815 * u.deg, height=2215 * u.m)
+
+
+def test_twilight_labeling():
+    date = datetime(2024, 1, 15, tzinfo=timezone.utc)
+    windows = twilight_windows_astro(date, LOC)
+    assert windows[0]["label"] is None
+    assert windows[-1]["label"] is None
+    labels = {w["label"] for w in windows if w["label"]}
+    assert labels == {"morning", "evening"}
+
+    morning = next(w for w in windows if w["label"] == "morning")
+    evening = next(w for w in windows if w["label"] == "evening")
+
+    # Approximate local solar time; ignores civil time zones and DST
+    offset_minutes = int(round((LOC.lon.to(u.deg).value / 15) * 60))
+    tz = timezone(timedelta(minutes=offset_minutes))
+
+    mid_m = morning["start"] + (morning["end"] - morning["start"]) / 2
+    mid_e = evening["start"] + (evening["end"] - evening["start"]) / 2
+    mid_m_local = mid_m.astimezone(tz)
+    mid_e_local = mid_e.astimezone(tz)
+    sunrise_local = morning["end"].astimezone(tz)
+    sunset_local = evening["start"].astimezone(tz)
+    local_midnight = datetime.combine(sunrise_local.date(), time(0), tz)
+
+    assert local_midnight < mid_m_local < sunrise_local
+    assert mid_e_local > sunset_local


### PR DESCRIPTION
## Goal:
- prevent mislabeling of morning/evening twilight windows

## Plan Stage:
- n/a

## Changes:
- classify each twilight window as morning or evening based on solar altitude trend
- propagate explicit window labels through the scheduler and summaries
- skip unlabeled windows when selecting targets and generating nightly summaries
- add regression tests for twilight labeling and update existing tests

## Assumptions & Units:
- sun altitude in degrees; windows computed over 48h span

## Tests:
- `ruff check twilight_planner_pkg/scheduler.py twilight_planner_pkg/tests/test_nightly_summary.py twilight_planner_pkg/tests/test_twilight_labeling.py`
- `isort --profile black twilight_planner_pkg/scheduler.py twilight_planner_pkg/tests/test_nightly_summary.py twilight_planner_pkg/tests/test_twilight_labeling.py --check-only`
- `black twilight_planner_pkg/scheduler.py twilight_planner_pkg/tests/test_nightly_summary.py twilight_planner_pkg/tests/test_twilight_labeling.py --check`
- `mypy twilight_planner_pkg/scheduler.py twilight_planner_pkg/tests/test_nightly_summary.py twilight_planner_pkg/tests/test_twilight_labeling.py --ignore-missing-imports` *(fails: existing type errors in unrelated modules)*
- `pytest -q`

## SIMLIB Impact:
- no changes to SIMLIB schema

## Risk & Rollback:
- revert commit to restore prior window labeling and scheduling behavior

------
https://chatgpt.com/codex/tasks/task_e_689da140bb1c83219502056469401af2