### PR TITLE
Aggregate SIMLIB epochs per SN

### DIFF
--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -1,0 +1,5 @@
+## Stage 1: Aggregate SIMLIB epochs by supernova
+**Goal**: group all scheduled epochs for a single SN into one SIMLIB LIBID block.
+**Success Criteria**: scheduler output has one LIBID per SN with `NOBS` equal to epoch count; regression test spans multiple nights.
+**Tests**: `pytest -q`
+**Status**: Complete

--- a/twilight_planner_pkg/tests/test_simlib_writer.py
+++ b/twilight_planner_pkg/tests/test_simlib_writer.py
@@ -130,3 +130,104 @@ def test_simlib_output(tmp_path, monkeypatch):
 
     assert lines[-1] == last_end_line
     assert any("SURVEY:" in line for line in lines[:10])
+
+
+def test_simlib_grouping_across_nights(tmp_path, monkeypatch):
+    data_path = (
+        Path(__file__).resolve().parents[2] / "data" / "ATLAS_2021_to25_cleaned.csv"
+    )
+    subset_csv = _make_subset_csv(data_path, tmp_path / "subset.csv", n=1)
+
+    from twilight_planner_pkg import scheduler
+
+    def mock_twilight_windows_for_local_night(date_local, loc):
+        start_morning = datetime(
+            date_local.year,
+            date_local.month,
+            date_local.day,
+            5,
+            0,
+            0,
+            tzinfo=timezone.utc,
+        )
+        end_morning = start_morning + timedelta(minutes=30)
+        return [
+            {
+                "start": start_morning,
+                "end": end_morning,
+                "label": "morning",
+                "night_date": date_local,
+            }
+        ]
+
+    def mock_best_time_with_moon(
+        sc, window, loc, step_min, min_alt_deg, min_moon_sep_deg
+    ):
+        start, _ = window
+        return 50.0, start + timedelta(minutes=5), 0.0, 0.0, 180.0
+
+    monkeypatch.setattr(
+        scheduler,
+        "twilight_windows_for_local_night",
+        mock_twilight_windows_for_local_night,
+    )
+    monkeypatch.setattr(scheduler, "_best_time_with_moon", mock_best_time_with_moon)
+    monkeypatch.setattr(scheduler, "great_circle_sep_deg", lambda *args, **kwargs: 0.0)
+    monkeypatch.setattr(
+        scheduler,
+        "RubinSkyProvider",
+        lambda: scheduler.SimpleSkyProvider(scheduler.SkyModelConfig()),
+    )
+
+    simlib_path = tmp_path / "plan.SIMLIB"
+
+    cfg = PlannerConfig(
+        lat_deg=0.0,
+        lon_deg=0.0,
+        height_m=0.0,
+        filters=["r"],
+        exposure_by_filter={"r": 3.0},
+        readout_s=1.0,
+        filter_change_s=0.0,
+        evening_cap_s=30.0,
+        morning_cap_s=30.0,
+        max_sn_per_night=1,
+        per_sn_cap_s=10.0,
+        min_moon_sep_by_filter={"r": 0.0},
+        require_single_time_for_all_filters=False,
+        min_alt_deg=0.0,
+        twilight_step_min=1,
+        allow_filter_changes_in_twilight=True,
+        simlib_out=str(simlib_path),
+    )
+
+    start_date = "2025-07-30"
+    end_date = "2025-07-31"
+
+    pernight_df, _ = plan_twilight_range_with_caps(
+        csv_path=str(subset_csv),
+        outdir=str(tmp_path),
+        start_date=start_date,
+        end_date=end_date,
+        cfg=cfg,
+        verbose=False,
+    )
+
+    assert len(pernight_df) == 2
+    sn_name = pd.read_csv(subset_csv)["name"].iloc[0]
+    lines = simlib_path.read_text().strip().splitlines()
+    libid_lines = [i for i, line in enumerate(lines) if line.startswith("LIBID:")]
+    assert len(libid_lines) == 1
+
+    libid_nums = [int(lines[i].split(":")[1]) for i in libid_lines]
+    assert libid_nums == list(range(1, len(libid_nums) + 1))
+
+    nobs_line = lines[libid_lines[0] + 1]
+    assert nobs_line.startswith("NOBS:")
+
+    comment_line = lines[libid_lines[0] + 2]
+    assert comment_line.strip() == f"# {sn_name}"
+    assert lines.count(f"# {sn_name}") == 1
+
+    s_lines = [line for line in lines if line.startswith("S:")]
+    assert int(nobs_line.split()[1]) == len(s_lines) == 2


### PR DESCRIPTION
- **Goal:** group all simulated visits for a supernova into a single SIMLIB LIBID block
- **Plan Stage:** [Stage 1](IMPLEMENTATION_PLAN.md)
- **Changes:**
  - buffer SIMLIB epochs by supernova and flush once at end of planning
  - remove per-visit `LIBID` streaming
  - add regression test for multi-night grouping
  - document implementation plan
  - verify test coverage for comment lines and sequential `LIBID` numbers
- **Assumptions & Units:** RA/DEC in degrees; `NOBS` equals total epochs
- **Tests:**
  - `ruff check .` *(fails: repository has pre-existing lint errors)*
  - `ruff check twilight_planner_pkg/tests/test_simlib_writer.py`
  - `black --check .` *(fails: many files would be reformatted)*
  - `black --check twilight_planner_pkg/tests/test_simlib_writer.py`
  - `isort --profile black --check-only twilight_planner_pkg/tests/test_simlib_writer.py`
  - `mypy twilight_planner_pkg` *(fails: missing type stubs and other errors)*
  - `pytest -q`
- **SIMLIB Impact:** ensures one `LIBID` per SN with accurate `NOBS`
- **Risk & Rollback:** revert commit to restore previous behavior


------
https://chatgpt.com/codex/tasks/task_e_689ebce954508321820367dba6e163b2