### PR TITLE
Add twilight window KPIs and flexible nightly reporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,20 @@ plan_twilight_range_with_caps("my_catalog.csv", "out", "2024-01-01", "2024-01-01
 The repository includes `data/demo_three_targets.csv` illustrating a simple
 three-target run.
 
+## Outputs
+
+The night/window summary CSV now includes the following columns capturing
+twilight timing and basic science metrics:
+
+- `window_start_utc`, `window_end_utc`, `window_duration_s`, `window_mid_utc`
+- `sun_alt_mid_deg`, `policy_filters_mid_csv`
+- `window_utilization`, `cap_utilization`, `cap_source`
+- `median_sky_mag_arcsec2`, `median_alt_deg`
+
+`window_cap_s` is populated from
+`PlannerConfig.morning_cap_s` or `PlannerConfig.evening_cap_s` according to the
+window label.
+
 ## Installation
 
 ```bash

--- a/twilight_planner_pkg/reports.py
+++ b/twilight_planner_pkg/reports.py
@@ -1,11 +1,18 @@
 """Reporting utilities for nightly metrics."""
+
 from __future__ import annotations
 
-from typing import Dict, Any
+from pathlib import Path
+from typing import Any, Dict
+
 import pandas as pd
 
 
-def summarize_night(plan_df: pd.DataFrame, twilight_window_s: float) -> Dict[str, Any]:
+def summarize_night(
+    plan_df: pd.DataFrame,
+    twilight: float | dict | pd.DataFrame,
+    outdir: str | None = None,
+) -> Dict[str, Any]:
     """Compute nightly efficiency and science KPIs from a plan.
 
     Parameters
@@ -15,8 +22,13 @@ def summarize_night(plan_df: pd.DataFrame, twilight_window_s: float) -> Dict[str
         columns are ``exposure_s``, ``readout_s``, ``filter_changes_s``,
         ``cross_filter_change_s``, ``slew_s``, ``filter`` and ``Name``. Optional
         columns ``airmass`` and ``moon_sep`` enable additional metrics.
-    twilight_window_s : float
-        Duration of the available twilight window in seconds.
+    twilight : float | dict | pandas.DataFrame
+        Total twilight duration in seconds (float), per-window durations
+        (mapping of label→seconds), or a DataFrame with columns
+        ``twilight_window`` and ``window_duration_s``.
+    outdir : str, optional
+        Directory to which ``nightly_metrics.csv`` will be written. Defaults to
+        current directory when ``None``.
 
     Returns
     -------
@@ -31,12 +43,14 @@ def summarize_night(plan_df: pd.DataFrame, twilight_window_s: float) -> Dict[str
     ``science_efficiency``
         ``science_exptime_s / total_used_s``
     ``twilight_utilization``
-        ``total_used_s / twilight_window_s``
+        ``total_used_s / twilight_total``
     ``color_completeness_frac``
         Fraction of supernovae observed in at least two filters.
     """
     totals = {
-        "science_exptime_s": float(plan_df.get("exposure_s", pd.Series(dtype=float)).sum()),
+        "science_exptime_s": float(
+            plan_df.get("exposure_s", pd.Series(dtype=float)).sum()
+        ),
         "readout_s": float(plan_df.get("readout_s", pd.Series(dtype=float)).sum()),
         "filter_change_s": float(
             plan_df.get("filter_changes_s", pd.Series(dtype=float)).sum()
@@ -44,23 +58,58 @@ def summarize_night(plan_df: pd.DataFrame, twilight_window_s: float) -> Dict[str
         ),
         "slew_s": float(plan_df.get("slew_s", pd.Series(dtype=float)).sum()),
     }
-    totals["overhead_s"] = totals["readout_s"] + totals["filter_change_s"] + totals["slew_s"]
+    totals["overhead_s"] = (
+        totals["readout_s"] + totals["filter_change_s"] + totals["slew_s"]
+    )
     totals["total_used_s"] = totals["science_exptime_s"] + totals["overhead_s"]
 
+    if isinstance(twilight, (int, float)):
+        twilight_total = float(twilight)
+        per_window: dict[str, float] = {}
+    elif isinstance(twilight, dict):
+        twilight_total = float(sum(twilight.values()))
+        per_window = {k: float(v) for k, v in twilight.items()}
+    else:
+        twilight_total = float(twilight["window_duration_s"].sum())
+        per_window = {
+            w: float(
+                twilight.loc[
+                    twilight["twilight_window"] == w, "window_duration_s"
+                ].sum()
+            )
+            for w in twilight["twilight_window"].unique()
+        }
+
     kpi: Dict[str, Any] = {}
-    kpi["science_efficiency"] = totals["science_exptime_s"] / max(1.0, totals["total_used_s"])
-    kpi["twilight_utilization"] = totals["total_used_s"] / max(1.0, twilight_window_s)
+    kpi["science_efficiency"] = totals["science_exptime_s"] / max(
+        1.0, totals["total_used_s"]
+    )
+    kpi["twilight_utilization"] = totals["total_used_s"] / max(1.0, twilight_total)
     if "airmass" in plan_df:
         kpi["median_airmass"] = float(plan_df["airmass"].median())
     if "moon_sep" in plan_df:
         kpi["median_moon_sep_deg"] = float(plan_df["moon_sep"].median())
-    kpi["filter_swaps"] = int((plan_df["filter"] != plan_df["filter"].shift()).sum() - 1 if len(plan_df) else 0)
-    kpi["filters_used"] = sorted(plan_df["filter"].unique().tolist()) if len(plan_df) else []
-    per_sn = plan_df.groupby("Name")["filter"].agg(lambda s: set(s)) if len(plan_df) else pd.Series()
+    kpi["filter_swaps"] = int(
+        (plan_df["filter"] != plan_df["filter"].shift()).sum() - 1
+        if len(plan_df)
+        else 0
+    )
+    kpi["filters_used"] = (
+        sorted(plan_df["filter"].unique().tolist()) if len(plan_df) else []
+    )
+    per_sn = (
+        plan_df.groupby("Name")["filter"].agg(lambda s: set(s))
+        if len(plan_df)
+        else pd.Series()
+    )
     kpi["color_completeness_frac"] = (
         float(per_sn.apply(lambda s: len(s) >= 2).mean()) if len(per_sn) else 0.0
     )
 
     metrics = {**totals, **kpi}
-    pd.DataFrame([metrics]).to_csv("twilight_outputs/nightly_metrics.csv", index=False)
+    metrics["twilight_total_s"] = twilight_total
+    if per_window:
+        metrics["twilight_per_window_s"] = per_window
+    out_path = Path(outdir or ".") / "nightly_metrics.csv"
+    pd.DataFrame([metrics]).to_csv(out_path, index=False)
     return metrics

--- a/twilight_planner_pkg/tests/test_nightly_summary.py
+++ b/twilight_planner_pkg/tests/test_nightly_summary.py
@@ -70,3 +70,11 @@ def test_nightly_summary_fields(tmp_path, monkeypatch):
     assert row["median_airmass"] == pytest.approx(am_expected, rel=1e-3)
     assert row["filters_used_csv"] == ",".join(sorted(pernight["filter"].unique()))
     assert row["n_planned"] == 1
+    assert "moon_sep" in pernight.columns
+    start = datetime(2024, 1, 1, 5, 0, 0, tzinfo=timezone.utc)
+    end = start + timedelta(minutes=30)
+    assert row["window_start_utc"] == pd.Timestamp(start).tz_convert("UTC").isoformat()
+    assert row["window_end_utc"] == pd.Timestamp(end).tz_convert("UTC").isoformat()
+    assert row["window_duration_s"] == 1800
+    assert row["cap_source"] == "morning_cap_s"
+    assert row["median_alt_deg"] == pytest.approx(pernight["alt_deg"].median())

--- a/twilight_planner_pkg/tests/test_reports.py
+++ b/twilight_planner_pkg/tests/test_reports.py
@@ -1,6 +1,7 @@
-import pathlib, sys
+import pathlib
+import sys
+
 import pandas as pd
-import pytest
 
 sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[2]))
 
@@ -27,8 +28,8 @@ def test_summarize_night_basic(tmp_path, monkeypatch):
     out_dir = tmp_path / "twilight_outputs"
     out_dir.mkdir()
     monkeypatch.chdir(tmp_path)
-    m = summarize_night(plan, twilight_window_s=600)
+    m = summarize_night(plan, twilight=600, outdir=str(out_dir))
     assert 0.0 <= m["science_efficiency"] <= 1.0
     assert m["color_completeness_frac"] >= 0.5
-    csv_path = tmp_path / "twilight_outputs" / "nightly_metrics.csv"
+    csv_path = out_dir / "nightly_metrics.csv"
     assert csv_path.exists()


### PR DESCRIPTION
- **Goal:** enrich nightly/window summaries with timing and science metrics; allow nightly reporter to accept per-window durations
- **Plan Stage:** In Progress (see `IMPLEMENTATION_PLAN.md`)
- **Changes:**
  - capture moon separation and per-visit sky mags during scheduling
  - augment night/window summary with mid-window timings, policy filters, utilization, and medians
  - make `summarize_night` accept float/dict/DataFrame twilight durations and write metrics to configurable directory
  - document new summary columns in README
- **Assumptions & Units:** times in seconds; angles in degrees; UTC timestamps
- **Tests:** `ruff check twilight_planner_pkg/scheduler.py twilight_planner_pkg/reports.py twilight_planner_pkg/tests/test_reports.py twilight_planner_pkg/tests/test_nightly_summary.py`, `black --check twilight_planner_pkg/scheduler.py twilight_planner_pkg/reports.py twilight_planner_pkg/tests/test_reports.py twilight_planner_pkg/tests/test_nightly_summary.py`, `isort --check-only --profile black twilight_planner_pkg/scheduler.py twilight_planner_pkg/reports.py twilight_planner_pkg/tests/test_reports.py twilight_planner_pkg/tests/test_nightly_summary.py`, `mypy twilight_planner_pkg` (missing stubs), `pytest -q`
- **SIMLIB Impact:** none; existing writer unaffected
- **Risk & Rollback:** revert commit to restore prior summary and reporting behavior

------
https://chatgpt.com/codex/tasks/task_e_689f6e5bdd6c8321a3b6c2aee0a9329f