### PR TITLE
Allow configurable twilight sun altitude range

### DIFF
--- a/notebook/README.md
+++ b/notebook/README.md
@@ -33,7 +33,7 @@ The planner schedules supernova (SN) observations during astronomical twilight b
 ### 2. Night‑by‑Night Loop
 For each UTC date in `START_DATE` … `END_DATE`:
 
-1. **Find astronomical twilight windows**: compute morning/evening intervals where the Sun altitude satisfies −18° < alt < 0° (`twilight_windows_astro`).
+1. **Find astronomical twilight windows**: compute morning/evening intervals where the Sun altitude satisfies `cfg.twilight_sun_alt_min_deg` < alt < `cfg.twilight_sun_alt_max_deg` (defaults −18° < alt < 0°) (`twilight_windows_astro`).
 2. **Set a conservative Moon‑separation guard**: use the max of `MIN_MOON_SEP_BY_FILTER` over loaded filters as a baseline; automatically ignore the constraint when the Moon is below the horizon.
 3. **Initialize window state**: for each window keep the current loaded filter (start with `START_FILTER`), filter-swap counters, and time caps (`MORNING_CAP_S` / `EVENING_CAP_S`).
 4. **Filter eligible SNe by “lifetime”**: using discovery time and `TYPICAL_DAYS_BY_TYPE` (with a 1.2× safety factor via `parse_sn_type_to_window_days`), accept only SNe still in their typical observability window on this date.

--- a/twilight_planner_pkg/README.md
+++ b/twilight_planner_pkg/README.md
@@ -82,12 +82,12 @@ plan_twilight_range_with_caps('/path/to/your.csv', '/tmp/out',
 > ### Key selection criteria recap:
 >
 > - A supernova must have a valid discovery date within the configured observation window.
-> - Must be observable at altitude ≥ `min_alt_deg` (default 20°) during at least one twilight window (Sun altitude between −18° and 0°).
+> - Must be observable at altitude ≥ `min_alt_deg` (default 20°) during at least one twilight window where the Sun altitude lies between `twilight_sun_alt_min_deg` and `twilight_sun_alt_max_deg` (defaults −18° to 0°).
 > - Eligibility duration after discovery is scaled from a `typical_days_by_type` value (or a default if type unknown) and multiplied by 1.2 to provide a buffer.
 > - Observation times must also pass the Moon separation rule, which applies a filter-dependent minimum separation, waived if the Moon is below the horizon.
 
 ### Twilight Windows & Best Time
-- Twilight windows are spans with Sun altitude $h_\odot \in [-18^\circ,0^\circ)$
+- Twilight windows are spans with Sun altitude $h_\odot \in [\texttt{twilight\_sun\_alt\_min\_deg},\texttt{twilight\_sun\_alt\_max\_deg})$ (defaults −18° to 0°)
 - Sample each window every `twilight_step_min` minutes
 - For each SN, choose the time of maximum altitude that passes altitude and Moon constraints (below)
 
@@ -372,7 +372,7 @@ Below is a compact table summarizing key default values, with direct links to th
 
 | Parameter | Default Value | Source & Link |
 | --- | --- | --- |
-| Sun altitude for twilight | −18° to 0° | — |
+| Sun altitude for twilight | `twilight_sun_alt_min_deg` to `twilight_sun_alt_max_deg` (default −18° to 0°) | — |
 | Minimum target altitude | 20° | — |
 | Hybrid detections threshold | 2 detections or 300 s | — |
 | Light‑curve (LC) threshold | 5 detections or 300 s | — |

--- a/twilight_planner_pkg/config.py
+++ b/twilight_planner_pkg/config.py
@@ -32,6 +32,8 @@ class PlannerConfig:
 
     # -- Visibility --------------------------------------------------------
     min_alt_deg: float = 30.0
+    twilight_sun_alt_min_deg: float = -18.0
+    twilight_sun_alt_max_deg: float = 0.0
 
     # -- Filters and hardware ---------------------------------------------
     filters: List[str] = field(default_factory=lambda: ["g", "r", "i", "z", "y"])

--- a/twilight_planner_pkg/main.py
+++ b/twilight_planner_pkg/main.py
@@ -8,10 +8,13 @@ Usage (example):
         --lat -30.2446 --lon -70.7494 --height 2663 \
         --strategy hybrid
 """
+
 import argparse
 from pathlib import Path
+
 from .config import PlannerConfig
 from .scheduler import plan_twilight_range_with_caps
+
 
 def build_parser():
     """Construct the command-line argument parser.
@@ -32,24 +35,66 @@ def build_parser():
     p.add_argument("--height", type=float, required=True, help="Elevation (m)")
     # Optional knobs
     p.add_argument("--min_alt", type=float, default=20.0)
-    p.add_argument("--filters", default="g,r,i,z", help="Comma-separated filter list, e.g. g,r,i,z")
-    p.add_argument("--exp", default="g:5,r:5,i:5,z:5", help="Exposure per filter seconds, e.g. g:5,r:5,i:5,z:5")
+    p.add_argument(
+        "--twilight-sun-alt-min",
+        type=float,
+        default=-18.0,
+        help="Minimum Sun altitude (deg) for twilight windows",
+    )
+    p.add_argument(
+        "--twilight-sun-alt-max",
+        type=float,
+        default=0.0,
+        help="Maximum Sun altitude (deg) for twilight windows",
+    )
+    p.add_argument(
+        "--filters", default="g,r,i,z", help="Comma-separated filter list, e.g. g,r,i,z"
+    )
+    p.add_argument(
+        "--exp",
+        default="g:5,r:5,i:5,z:5",
+        help="Exposure per filter seconds, e.g. g:5,r:5,i:5,z:5",
+    )
     p.add_argument("--evening_cap", type=float, default=600.0)
     p.add_argument("--morning_cap", type=float, default=600.0)
     p.add_argument("--per_sn_cap", type=float, default=120.0)
     p.add_argument("--max_sn", type=int, default=10)
     p.add_argument("--twilight_step", type=int, default=2)
-    p.add_argument("--require_single_time", action="store_true", help="Require one time satisfying moon sep for all filters")
-    p.add_argument("--strategy", choices=["hybrid","lc"], default="hybrid",
-                   help="Priority strategy: 'hybrid' drops after quick color, 'lc' pursues full light curves")
-    p.add_argument("--hybrid-detections", type=int, default=2,
-                   help="Detections across ≥2 filters before Hybrid goal is met")
-    p.add_argument("--hybrid-exposure", type=float, default=300.0,
-                   help="Total exposure seconds before Hybrid goal is met")
-    p.add_argument("--lc-detections", type=int, default=5,
-                   help="Detections required for LSST-only light-curve goal")
-    p.add_argument("--lc-exposure", type=float, default=300.0,
-                   help="Total exposure seconds for LSST-only goal")
+    p.add_argument(
+        "--require_single_time",
+        action="store_true",
+        help="Require one time satisfying moon sep for all filters",
+    )
+    p.add_argument(
+        "--strategy",
+        choices=["hybrid", "lc"],
+        default="hybrid",
+        help="Priority strategy: 'hybrid' drops after quick color, 'lc' pursues full light curves",
+    )
+    p.add_argument(
+        "--hybrid-detections",
+        type=int,
+        default=2,
+        help="Detections across ≥2 filters before Hybrid goal is met",
+    )
+    p.add_argument(
+        "--hybrid-exposure",
+        type=float,
+        default=300.0,
+        help="Total exposure seconds before Hybrid goal is met",
+    )
+    p.add_argument(
+        "--lc-detections",
+        type=int,
+        default=5,
+        help="Detections required for LSST-only light-curve goal",
+    )
+    p.add_argument(
+        "--lc-exposure",
+        type=float,
+        default=300.0,
+        help="Total exposure seconds for LSST-only goal",
+    )
     p.add_argument("--simlib-out", help="Path to write SNANA SIMLIB (optional)")
     p.add_argument("--simlib-survey", default="LSST_TWILIGHT")
     p.add_argument("--simlib-filters", default="ugrizY")
@@ -61,6 +106,7 @@ def build_parser():
     p.add_argument("--read-noise-e", type=float, default=9.0)
     p.add_argument("--allow-filter-changes-in-twilight", action="store_true")
     return p
+
 
 def parse_exp_map(s: str):
     """Convert a comma-separated exposure mapping into a dictionary.
@@ -82,6 +128,7 @@ def parse_exp_map(s: str):
             m[k.strip()] = float(v.strip())
     return m
 
+
 def main():
     """Run the command-line planner.
 
@@ -91,8 +138,12 @@ def main():
     args = build_parser().parse_args()
     exp_map = parse_exp_map(args.exp)
     cfg = PlannerConfig(
-        lat_deg=args.lat, lon_deg=args.lon, height_m=args.height,
+        lat_deg=args.lat,
+        lon_deg=args.lon,
+        height_m=args.height,
         min_alt_deg=args.min_alt,
+        twilight_sun_alt_min_deg=args.twilight_sun_alt_min,
+        twilight_sun_alt_max_deg=args.twilight_sun_alt_max,
         filters=[x.strip() for x in args.filters.split(",") if x.strip()],
         exposure_by_filter=exp_map,
         twilight_step_min=args.twilight_step,
@@ -126,6 +177,7 @@ def main():
         cfg=cfg,
         verbose=True,
     )
+
 
 if __name__ == "__main__":
     main()

--- a/twilight_planner_pkg/scheduler.py
+++ b/twilight_planner_pkg/scheduler.py
@@ -176,7 +176,12 @@ def plan_twilight_range_with_caps(
 
     for day in nights_iter:
         # Here 'day' is interpreted as *local* civil date of the evening block
-        windows = twilight_windows_for_local_night(day.date(), site)
+        windows = twilight_windows_for_local_night(
+            day.date(),
+            site,
+            cfg.twilight_sun_alt_min_deg,
+            cfg.twilight_sun_alt_max_deg,
+        )
         if not windows:
             continue
         # Conservative baseline Moon separation used while sampling best times.

--- a/twilight_planner_pkg/tests/test_carousel_capacity.py
+++ b/twilight_planner_pkg/tests/test_carousel_capacity.py
@@ -30,7 +30,9 @@ def test_carousel_capacity_enforced(tmp_path, monkeypatch):
 
     from twilight_planner_pkg import scheduler
 
-    def mock_twilight_windows_for_local_night(date_local, loc):
+    def mock_twilight_windows_for_local_night(
+        date_local, loc, min_sun_alt_deg=-18.0, max_sun_alt_deg=0.0
+    ):
         start = datetime(
             date_local.year,
             date_local.month,

--- a/twilight_planner_pkg/tests/test_local_night.py
+++ b/twilight_planner_pkg/tests/test_local_night.py
@@ -1,5 +1,5 @@
 import types
-from datetime import date, datetime, timedelta, timezone
+from datetime import date, datetime, timezone
 
 import astropy.units as u
 import pandas as pd
@@ -25,17 +25,29 @@ def test_scheduler_passes_date_to_local_night(monkeypatch, tmp_path):
     """Ensure the scheduler passes a datetime.date into twilight_windows_for_local_night."""
     seen_types = []
 
-    def fake_twilight_windows_for_local_night(date_local, loc):
+    def fake_twilight_windows_for_local_night(
+        date_local, loc, min_sun_alt_deg=-18.0, max_sun_alt_deg=0.0
+    ):
         seen_types.append(type(date_local))
         d = datetime(2025, 1, 1, 0, 0, tzinfo=timezone.utc)
         return [
-            {"start": d.replace(hour=23, minute=45), "end": d.replace(day=2, hour=1, minute=24), "label": "evening"},
-            {"start": d.replace(hour=8, minute=9), "end": d.replace(hour=9, minute=49), "label": "morning"},
+            {
+                "start": d.replace(hour=23, minute=45),
+                "end": d.replace(day=2, hour=1, minute=24),
+                "label": "evening",
+            },
+            {
+                "start": d.replace(hour=8, minute=9),
+                "end": d.replace(hour=9, minute=49),
+                "label": "morning",
+            },
         ]
 
     import twilight_planner_pkg.scheduler as sched
 
-    monkeypatch.setattr(sched, "twilight_windows_for_local_night", fake_twilight_windows_for_local_night)
+    monkeypatch.setattr(
+        sched, "twilight_windows_for_local_night", fake_twilight_windows_for_local_night
+    )
 
     def fake_read_csv(_):
         return pd.DataFrame(
@@ -114,6 +126,8 @@ def test_scheduler_passes_date_to_local_night(monkeypatch, tmp_path):
         typical_days_by_type={},
         default_typical_days=100,
         sun_alt_policy=[],
+        twilight_sun_alt_min_deg=-18.0,
+        twilight_sun_alt_max_deg=0.0,
     )
 
     monkeypatch.setattr(sched, "RubinSkyProvider", lambda *a, **k: None)
@@ -194,13 +208,23 @@ def test_coarse_moon_gate_uses_min(monkeypatch, tmp_path):
         typical_days_by_type={},
         default_typical_days=100,
         sun_alt_policy=[],
+        twilight_sun_alt_min_deg=-18.0,
+        twilight_sun_alt_max_deg=0.0,
     )
 
-    def fake_local_night(date_local, loc):
+    def fake_local_night(date_local, loc, min_sun_alt_deg=-18.0, max_sun_alt_deg=0.0):
         d = datetime(2025, 1, 1, 0, 0, tzinfo=timezone.utc)
         return [
-            {"start": d.replace(hour=23, minute=45), "end": d.replace(day=2, hour=1, minute=24), "label": "evening"},
-            {"start": d.replace(hour=8, minute=9), "end": d.replace(hour=9, minute=49), "label": "morning"},
+            {
+                "start": d.replace(hour=23, minute=45),
+                "end": d.replace(day=2, hour=1, minute=24),
+                "label": "evening",
+            },
+            {
+                "start": d.replace(hour=8, minute=9),
+                "end": d.replace(hour=9, minute=49),
+                "label": "morning",
+            },
         ]
 
     monkeypatch.setattr(sched, "twilight_windows_for_local_night", fake_local_night)

--- a/twilight_planner_pkg/tests/test_nightly_summary.py
+++ b/twilight_planner_pkg/tests/test_nightly_summary.py
@@ -26,7 +26,9 @@ def test_nightly_summary_fields(tmp_path, monkeypatch):
     df.to_csv(csv, index=False)
     from twilight_planner_pkg import scheduler
 
-    def mock_twilight_windows_for_local_night(date_local, loc):
+    def mock_twilight_windows_for_local_night(
+        date_local, loc, min_sun_alt_deg=-18.0, max_sun_alt_deg=0.0
+    ):
         start = datetime(
             date_local.year,
             date_local.month,

--- a/twilight_planner_pkg/tests/test_planner_features.py
+++ b/twilight_planner_pkg/tests/test_planner_features.py
@@ -111,7 +111,9 @@ def test_window_cap_skips_last(tmp_path, monkeypatch):
 
     from twilight_planner_pkg import scheduler
 
-    def mock_twilight_windows_for_local_night(date_local, loc):
+    def mock_twilight_windows_for_local_night(
+        date_local, loc, min_sun_alt_deg=-18.0, max_sun_alt_deg=0.0
+    ):
         start = datetime(
             date_local.year,
             date_local.month,

--- a/twilight_planner_pkg/tests/test_scheduler.py
+++ b/twilight_planner_pkg/tests/test_scheduler.py
@@ -32,7 +32,9 @@ def test_plan_twilight_range_basic(tmp_path, monkeypatch):
     # Mock astronomy-heavy helpers for deterministic behaviour
     from twilight_planner_pkg import scheduler
 
-    def mock_twilight_windows_for_local_night(date_local, loc):
+    def mock_twilight_windows_for_local_night(
+        date_local, loc, min_sun_alt_deg=-18.0, max_sun_alt_deg=0.0
+    ):
         start_morning = datetime(
             date_local.year,
             date_local.month,
@@ -172,7 +174,9 @@ def test_sun_alt_policy_enforced(tmp_path, monkeypatch):
 
     from twilight_planner_pkg import scheduler
 
-    def mock_twilight_windows_for_local_night(date_local, loc):
+    def mock_twilight_windows_for_local_night(
+        date_local, loc, min_sun_alt_deg=-18.0, max_sun_alt_deg=0.0
+    ):
         start = datetime(
             date_local.year,
             date_local.month,
@@ -263,7 +267,9 @@ def test_exposure_ladder_applied(tmp_path, monkeypatch):
 
     from twilight_planner_pkg import astro_utils, scheduler
 
-    def mock_twilight_windows_for_local_night(date_local, loc):
+    def mock_twilight_windows_for_local_night(
+        date_local, loc, min_sun_alt_deg=-18.0, max_sun_alt_deg=0.0
+    ):
         start = datetime(
             date_local.year,
             date_local.month,

--- a/twilight_planner_pkg/tests/test_simlib_writer.py
+++ b/twilight_planner_pkg/tests/test_simlib_writer.py
@@ -24,7 +24,9 @@ def test_simlib_output(tmp_path, monkeypatch):
 
     from twilight_planner_pkg import scheduler
 
-    def mock_twilight_windows_for_local_night(date_local, loc):
+    def mock_twilight_windows_for_local_night(
+        date_local, loc, min_sun_alt_deg=-18.0, max_sun_alt_deg=0.0
+    ):
         start_morning = datetime(
             date_local.year,
             date_local.month,


### PR DESCRIPTION
- **Goal:** expose configurable twilight sun altitude range and propagate through utilities
- **Plan Stage:** Stage 1 (see IMPLEMENTATION_PLAN.md)
- **Changes:**
  - add `twilight_sun_alt_min_deg`/`twilight_sun_alt_max_deg` to `PlannerConfig`
  - parameterise `twilight_windows_astro` and `twilight_windows_for_local_night`
  - thread configuration through scheduler and CLI
  - document configurable twilight bounds and add regression test
- **Assumptions & Units:** sun altitudes in degrees
- **Tests:**
  - `ruff check twilight_planner_pkg/config.py twilight_planner_pkg/astro_utils.py twilight_planner_pkg/scheduler.py twilight_planner_pkg/main.py twilight_planner_pkg/tests/test_astro_utils.py twilight_planner_pkg/tests/test_carousel_capacity.py twilight_planner_pkg/tests/test_planner_features.py twilight_planner_pkg/tests/test_simlib_writer.py twilight_planner_pkg/tests/test_nightly_summary.py twilight_planner_pkg/tests/test_local_night.py twilight_planner_pkg/tests/test_scheduler.py`
  - `black --check twilight_planner_pkg/config.py twilight_planner_pkg/astro_utils.py twilight_planner_pkg/scheduler.py twilight_planner_pkg/main.py twilight_planner_pkg/tests/test_astro_utils.py twilight_planner_pkg/tests/test_carousel_capacity.py twilight_planner_pkg/tests/test_planner_features.py twilight_planner_pkg/tests/test_simlib_writer.py twilight_planner_pkg/tests/test_nightly_summary.py twilight_planner_pkg/tests/test_local_night.py twilight_planner_pkg/tests/test_scheduler.py`
  - `isort --profile black --check-only twilight_planner_pkg/config.py twilight_planner_pkg/astro_utils.py twilight_planner_pkg/scheduler.py twilight_planner_pkg/main.py twilight_planner_pkg/tests/test_astro_utils.py twilight_planner_pkg/tests/test_carousel_capacity.py twilight_planner_pkg/tests/test_planner_features.py twilight_planner_pkg/tests/test_simlib_writer.py twilight_planner_pkg/tests/test_nightly_summary.py twilight_planner_pkg/tests/test_local_night.py twilight_planner_pkg/tests/test_scheduler.py`
  - `mypy --ignore-missing-imports twilight_planner_pkg/config.py twilight_planner_pkg/astro_utils.py twilight_planner_pkg/main.py` *(fails: missing type stubs and existing typing errors)*
  - `pytest -q`
- **SIMLIB Impact:** none
- **Risk & Rollback:** revert commit to restore prior fixed twilight altitude range

------
https://chatgpt.com/codex/tasks/task_e_68a00cde61448321a4604d28708a7712