### PR TITLE
Add automatic twilight window caps based on window duration

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,9 +72,10 @@ twilight timing and basic science metrics:
 - `window_utilization`, `cap_utilization`, `cap_source`
 - `median_sky_mag_arcsec2`, `median_alt_deg`
 
-`window_cap_s` is populated from
-`PlannerConfig.morning_cap_s` or `PlannerConfig.evening_cap_s` according to the
-window label.
+`window_cap_s` records the effective limit on scheduled time in each twilight
+window. It comes from `PlannerConfig.morning_cap_s` or `PlannerConfig.evening_cap_s`.
+When these are set to "auto" (the default), the cap equals the true duration of
+each window; otherwise a fixed number of seconds is used.
 
 ## Installation
 

--- a/twilight_planner_pkg/README.md
+++ b/twilight_planner_pkg/README.md
@@ -20,7 +20,7 @@ python -m twilight_planner_pkg.main --csv your.csv --out results \
     --start 2024-01-01 --end 2024-01-07 \
     --lat -30.2446 --lon -70.7494 --height 2663 \
     --filters g,r,i,z --exp g:5,r:5,i:5,z:5 \
-    --min_alt 20 --evening_cap 600 --morning_cap 600 \
+    --min_alt 20 --evening_cap auto --morning_cap auto \
     --per_sn_cap 120 --max_sn 10 --strategy hybrid \
     --hybrid-detections 2 --hybrid-exposure 300 \
     --simlib-out results/night.SIMLIB --simlib-survey LSST_TWILIGHT
@@ -95,7 +95,7 @@ plan_twilight_range_with_caps('/path/to/your.csv', '/tmp/out',
 - Rank visible SNe by need score (how far from meeting the current goal) and altitude
 - Keep the top `max_sn_per_night` globally; split by window (0=morning, 1=evening)
 - Within each window, schedule via greedy nearest‑neighbor on great‑circle distance
-- Enforce window caps (`morning_cap_s`, `evening_cap_s`) and per‑SN cap (`per_sn_cap_s`); trim filters greedily to fit
+- Enforce window caps (`morning_cap_s`, `evening_cap_s`, default "auto" uses window duration) and per‑SN cap (`per_sn_cap_s`); trim filters greedily to fit
 
 > ### Prioritization strategy recap:
 >

--- a/twilight_planner_pkg/config.py
+++ b/twilight_planner_pkg/config.py
@@ -8,7 +8,7 @@ at Cerro Pach\u00f3n and can be customised for testing purposes.
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Dict, List, Optional, Tuple
+from typing import Dict, List, Literal, Optional, Tuple
 
 
 @dataclass
@@ -88,8 +88,8 @@ class PlannerConfig:
 
     # -- Time caps ---------------------------------------------------------
     per_sn_cap_s: float = 600.0
-    morning_cap_s: float = 1800.0
-    evening_cap_s: float = 1800.0
+    morning_cap_s: float | Literal["auto"] = "auto"
+    evening_cap_s: float | Literal["auto"] = "auto"
     twilight_step_min: int = 2
     max_sn_per_night: int = 20
 

--- a/twilight_planner_pkg/main.py
+++ b/twilight_planner_pkg/main.py
@@ -9,6 +9,8 @@ Usage (example):
         --strategy hybrid
 """
 
+from __future__ import annotations
+
 import argparse
 from pathlib import Path
 
@@ -55,8 +57,16 @@ def build_parser():
         default="g:5,r:5,i:5,z:5",
         help="Exposure per filter seconds, e.g. g:5,r:5,i:5,z:5",
     )
-    p.add_argument("--evening_cap", type=float, default=600.0)
-    p.add_argument("--morning_cap", type=float, default=600.0)
+    p.add_argument(
+        "--evening_cap",
+        default="auto",
+        help="Cap seconds in evening twilight; number or 'auto' to use window duration",
+    )
+    p.add_argument(
+        "--morning_cap",
+        default="auto",
+        help="Cap seconds in morning twilight; number or 'auto' to use window duration",
+    )
     p.add_argument("--per_sn_cap", type=float, default=120.0)
     p.add_argument("--max_sn", type=int, default=10)
     p.add_argument("--twilight_step", type=int, default=2)
@@ -129,6 +139,23 @@ def parse_exp_map(s: str):
     return m
 
 
+def _parse_cap(val: str) -> float | str:
+    """Parse a window cap argument.
+
+    Parameters
+    ----------
+    val : str
+        Value provided on the command line.
+
+    Returns
+    -------
+    float | str
+        ``"auto"`` to use window duration or the numeric cap in seconds.
+    """
+
+    return float(val) if val != "auto" else "auto"
+
+
 def main():
     """Run the command-line planner.
 
@@ -147,8 +174,8 @@ def main():
         filters=[x.strip() for x in args.filters.split(",") if x.strip()],
         exposure_by_filter=exp_map,
         twilight_step_min=args.twilight_step,
-        evening_cap_s=args.evening_cap,
-        morning_cap_s=args.morning_cap,
+        evening_cap_s=_parse_cap(args.evening_cap),
+        morning_cap_s=_parse_cap(args.morning_cap),
         per_sn_cap_s=args.per_sn_cap,
         max_sn_per_night=args.max_sn,
         require_single_time_for_all_filters=args.require_single_time,

--- a/twilight_planner_pkg/tests/test_config.py
+++ b/twilight_planner_pkg/tests/test_config.py
@@ -1,4 +1,5 @@
-import pathlib, sys
+import pathlib
+import sys
 
 # Ensure package root is importable
 sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[2]))
@@ -10,13 +11,15 @@ def test_default_config_values():
     cfg = PlannerConfig(10.0, 20.0, 30.0)
     assert cfg.filters == ["g", "r", "i", "z", "y"]
     assert cfg.exposure_by_filter["g"] == 15.0
-    assert cfg.evening_cap_s == 1800.0
+    assert cfg.evening_cap_s == "auto"
+    assert cfg.morning_cap_s == "auto"
 
 
 def test_custom_overrides():
     custom_filters = ["g", "r"]
     custom_typical = {"Ia": 40}
-    cfg = PlannerConfig(10.0, 20.0, 30.0, filters=custom_filters,
-                        typical_days_by_type=custom_typical)
+    cfg = PlannerConfig(
+        10.0, 20.0, 30.0, filters=custom_filters, typical_days_by_type=custom_typical
+    )
     assert cfg.filters == custom_filters
     assert cfg.typical_days_by_type == custom_typical


### PR DESCRIPTION
## Goal
Allow twilight scheduler to derive morning/evening caps from the actual window length when configured with "auto" and document the new behaviour.

## Plan Stage
N/A

## Changes
- Support `"auto"` for `morning_cap_s` and `evening_cap_s` in `PlannerConfig`
- Compute caps from window duration and track source in nightly summaries
- Expose `--morning_cap/--evening_cap` CLI options as strings with default `auto`
- Document automatic caps in both READMEs
- Add test covering auto-cap behaviour

## Assumptions & Units
- Twilight window durations and caps measured in seconds

## Tests
- `ruff check twilight_planner_pkg/config.py twilight_planner_pkg/main.py twilight_planner_pkg/scheduler.py twilight_planner_pkg/tests/test_config.py twilight_planner_pkg/tests/test_scheduler.py`
- `isort --profile black --check-only twilight_planner_pkg/config.py twilight_planner_pkg/main.py twilight_planner_pkg/scheduler.py twilight_planner_pkg/tests/test_config.py twilight_planner_pkg/tests/test_scheduler.py`
- `black --check twilight_planner_pkg/config.py twilight_planner_pkg/main.py twilight_planner_pkg/scheduler.py twilight_planner_pkg/tests/test_config.py twilight_planner_pkg/tests/test_scheduler.py`
- `mypy twilight_planner_pkg` *(fails: missing stubs for astropy/pandas and existing type errors)*
- `pytest -q`

## SIMLIB Impact
No SIMLIB fields changed.

## Risk & Rollback
- Low risk; new behaviour gated behind `"auto"` (default). Revert commit to restore fixed caps.


------
https://chatgpt.com/codex/tasks/task_e_68a0208e0b948321aa43ffb0aaa128c2