### PR TITLE
Record end-of-visit timestamps for scheduled SNe

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,9 @@ three-target run.
 
 ## Outputs
 
+The per-SN planning CSV now includes an `sn_end_utc` column giving the
+end of each visit (start time plus total scheduled duration).
+
 The night/window summary CSV now includes the following columns capturing
 twilight timing and basic science metrics:
 

--- a/twilight_planner_pkg/scheduler.py
+++ b/twilight_planner_pkg/scheduler.py
@@ -571,19 +571,22 @@ def plan_twilight_range_with_caps(
                                     "mag": -99.0,
                                 }
                             )
+                        # Observation start and end times in UTC
+                        start_utc = pd.Timestamp(t["best_time_utc"])
+                        if start_utc.tzinfo is None:
+                            start_utc = start_utc.tz_localize("UTC")
+                        else:
+                            start_utc = start_utc.tz_convert("UTC")
+                        total_s = round(timing["total_s"], 2)
+                        end_utc = start_utc + pd.to_timedelta(total_s, unit="s")
                         row = {
                             "date": day.date().isoformat(),
                             "twilight_window": window_label_out,
                             "SN": t["Name"],
                             "RA_deg": round(t["RA_deg"], 6),
                             "Dec_deg": round(t["Dec_deg"], 6),
-                            "best_twilight_time_utc": (
-                                pd.Timestamp(t["best_time_utc"])
-                                .tz_convert("UTC")
-                                .isoformat()
-                                if isinstance(t["best_time_utc"], pd.Timestamp)
-                                else str(t["best_time_utc"])
-                            ),
+                            "best_twilight_time_utc": start_utc.isoformat(),
+                            "sn_end_utc": end_utc.isoformat(),
                             "filter": f,
                             "t_exp_s": round(exp_s, 1),
                             "airmass": round(air, 3),
@@ -633,11 +636,7 @@ def plan_twilight_range_with_caps(
                                 if f == filters_used[0]
                                 else False
                             ),
-                            "total_time_s": (
-                                round(timing["total_s"], 2)
-                                if f == filters_used[0]
-                                else 0.0
-                            ),
+                            "total_time_s": (total_s if f == filters_used[0] else 0.0),
                             "elapsed_overhead_s": (
                                 round(timing.get("elapsed_overhead_s", 0.0), 2)
                                 if f == filters_used[0]

--- a/twilight_planner_pkg/tests/test_scheduler.py
+++ b/twilight_planner_pkg/tests/test_scheduler.py
@@ -127,6 +127,7 @@ def test_plan_twilight_range_basic(tmp_path, monkeypatch):
         "RA_deg",
         "Dec_deg",
         "best_twilight_time_utc",
+        "sn_end_utc",
         "filter",
         "t_exp_s",
         "airmass",
@@ -144,6 +145,13 @@ def test_plan_twilight_range_basic(tmp_path, monkeypatch):
     assert expected_cols.issubset(pernight_df.columns)
 
     assert (pernight_df["t_exp_s"] >= 0).all()
+
+    # End time equals start time plus total visit duration
+    mask = pernight_df["total_time_s"] > 0
+    starts = pd.to_datetime(pernight_df.loc[mask, "best_twilight_time_utc"], utc=True)
+    ends = pd.to_datetime(pernight_df.loc[mask, "sn_end_utc"], utc=True)
+    durations = pernight_df.loc[mask, "total_time_s"]
+    assert ((ends - starts).dt.total_seconds().round(3) == durations.round(3)).all()
 
     # ------------------------------------------------------------------
     # nights_df checks


### PR DESCRIPTION
## Goal
Expose end-of-visit timestamps for each supernova in the twilight schedule.

## Plan Stage
N/A

## Changes
- Compute `sn_end_utc` from the start time and total visit duration
- Test that `sn_end_utc` matches `best_twilight_time_utc + total_time_s`
- Document the new column in README

## Assumptions & Units
- Times are UTC; `total_time_s` measured in seconds

## Tests
- `ruff check twilight_planner_pkg/scheduler.py twilight_planner_pkg/tests/test_scheduler.py`
- `isort --check-only --profile black twilight_planner_pkg/scheduler.py twilight_planner_pkg/tests/test_scheduler.py`
- `black --check twilight_planner_pkg/scheduler.py twilight_planner_pkg/tests/test_scheduler.py`
- `mypy --ignore-missing-imports twilight_planner_pkg/scheduler.py twilight_planner_pkg/tests/test_scheduler.py` *(fails: missing type information in dependencies)*
- `pytest -q`

## SIMLIB Impact
Adds end-of-visit timestamp to per-SN CSV; no SIMLIB field changes.

## Risk & Rollback
Low risk; revert commit to drop `sn_end_utc` column if issues arise.

------
https://chatgpt.com/codex/tasks/task_e_68a0dd4c562c8321a15dc49ae7c6c3cb