### PR TITLE
Add true sequential schedule export

### DIFF
--- a/notebook/README.md
+++ b/notebook/README.md
@@ -15,7 +15,8 @@ The planner schedules supernova (SN) observations during astronomical twilight b
 
 ### Outputs
 
-- Per-SN plan CSV (one row per scheduled visit).
+- Per-SN plan CSV (one row per scheduled visit). Represents the **best-in-theory** schedule keyed to each target's `best_time_utc`; times may overlap across different SNe and do not reflect the serialized on-sky order.
+- True sequence CSV `lsst_twilight_sequence_true_<start>_to_<end>.csv` — **true, non-overlapping execution order** within each twilight window. Visits are packed as soon as the previous one ends (ignoring `best_time_utc` slack); `preferred_best_utc` records the original preference. Columns include `order_in_window`, `sn_start_utc`, `sn_end_utc`, and `filters_used_csv`. One row per SN visit (multi-filter visits are a single row).
 - Per-night summary CSV (morning/evening window statistics).
 - Optional SNANA SIMLIB file for simulations.
 
@@ -70,9 +71,11 @@ For each window index `idx_w` present that night:
 6. **Restore exposures if overridden**: if an exposure ladder was applied for this window, revert to the original `cfg.exposure_by_filter`.
 
 ### 4. Outputs
-- **Per-SN CSV**: `lsst_twilight_plan_<start>_to_<end>.csv`  
-  One row per scheduled visit with date, window, best time, filter, `t_exp_s`, airmass/altitude, sky brightness, photometric terms (`ZPT`, `SKYSIG`, `NEA`, `RDNOISE`, `GAIN`), saturation/non-linear flags, priority, and time breakdown (slew/readout/exposure/filter changes/total).
-- **Per-night summary CSV**: `lsst_twilight_summary_<start>_to_<end>.csv`  
+- **Per-SN CSV**: `lsst_twilight_plan_<start>_to_<end>.csv`
+  One row per scheduled visit with date, window, best time, filter, `t_exp_s`, airmass/altitude, sky brightness, photometric terms (`ZPT`, `SKYSIG`, `NEA`, `RDNOISE`, `GAIN`), saturation/non-linear flags, priority, and time breakdown (slew/readout/exposure/filter changes/total). Represents the **best-in-theory** schedule keyed to each target's `best_time_utc`; times may overlap across different SNe and do not reflect the serialized on-sky order.
+- **True sequence CSV**: `lsst_twilight_sequence_true_<start>_to_<end>.csv`
+  **True, non-overlapping execution order** within each twilight window. Visits are packed as soon as the previous one ends (ignoring `best_time_utc` slack); the original preference is stored in `preferred_best_utc`. Columns include `order_in_window`, `sn_start_utc`, `sn_end_utc`, and `filters_used_csv`. One row per SN visit (multi-filter visits are a single row).
+- **Per-night summary CSV**: `lsst_twilight_summary_<start>_to_<end>.csv`
   One row per window: candidate/planned counts, time usage vs. cap, swap counts, internal filter changes, mean slew, median airmass, loaded filters, actually used filters.
 - **SIMLIB (optional)**: if `SIMLIB_OUT` is set, a SNANA-compatible library with all `EPOCH`s is produced.
 

--- a/twilight_planner_pkg/README.md
+++ b/twilight_planner_pkg/README.md
@@ -333,7 +333,8 @@ When `--simlib-out` is provided, the planner writes `S:` rows with the following
 ---
 
 ## Outputs
-- Per‑SN plan — CSV: date, window, chosen time, altitude, filters, exposure settings, and a detailed time budget (slew/readout/filter‑change)
+- Per‑SN plan — CSV: date, window, chosen time, altitude, filters, exposure settings, and a detailed time budget (slew/readout/filter‑change). Represents the **best‑in‑theory** schedule keyed to each target's `best_time_utc`; times may overlap across different SNe and do not reflect the serialized on‑sky order.
+- True sequence CSV — `lsst_twilight_sequence_true_<start>_to_<end>.csv`: **true, non‑overlapping execution order** within each twilight window. Visits are packed as soon as the previous one ends (ignoring `best_time_utc` slack); the original preference is recorded as `preferred_best_utc`. Columns include `order_in_window`, `sn_start_utc`, `sn_end_utc`, and `filters_used_csv`. One row per SN visit (multi‑filter visits are a single row).
 - Night summary — CSV: counts of visible vs planned targets, cumulative time per window
 - SIMLIB — optional SNANA SIMLIB for the planned visits
 


### PR DESCRIPTION
## Goal
- capture true per-window execution order without altering existing per-SN CSVs

## Changes
- track a running UTC clock per twilight window and record sequential visit rows
- include cross-target filter-change time in elapsed overhead and window caps
- write `lsst_twilight_sequence_true_*` CSV alongside existing plan and summary outputs
- document distinction between best-in-theory plan CSV and true packed sequence CSV

## Testing
- `ruff check twilight_planner_pkg/scheduler.py`
- `black --check twilight_planner_pkg/scheduler.py`
- `isort --check-only --profile black twilight_planner_pkg/scheduler.py`
- `mypy twilight_planner_pkg/*.py` *(fails: missing stubs for pandas/astropy)*
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a0e82049f48321be1b090e65f7853a