### PR TITLE
Make first-epoch cadence bonus configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,14 @@ Moon–target separations use Astropy's `get_body('moon')` in a shared AltAz
 frame.  If the Moon is below the horizon, the separation requirement is
 automatically waived.
 
+### Cadence constraint (per-filter)
+
+Each filter maintains its own last-observed MJD. Repeats in the same band are
+gated until `cadence_days_target - cadence_jitter_days` days have elapsed.
+Filters nearing their due date receive a Gaussian "due-soon" bonus so the
+scheduler prefers them. Different filters may still be taken within a single
+visit because cadence is tracked per filter.
+
 Airmass calculations adopt the "simple" formula of Kasten & Young (1989), and
 the overhead values above follow Rubin Observatory technical notes.
 
@@ -74,6 +82,8 @@ twilight timing and basic science metrics:
 - `sun_alt_mid_deg`, `policy_filters_mid_csv`
 - `window_utilization`, `cap_utilization`, `cap_source`
 - `median_sky_mag_arcsec2`, `median_alt_deg`
+- `cad_median_abs_err_by_filter_csv`, `cad_within_pct_by_filter_csv`
+- `cad_median_abs_err_all_d`, `cad_within_pct_all`
 
 `window_cap_s` records the effective limit on scheduled time in each twilight
 window. It comes from `PlannerConfig.morning_cap_s` or `PlannerConfig.evening_cap_s`.

--- a/notebook/README.md
+++ b/notebook/README.md
@@ -13,6 +13,18 @@ The planner schedules supernova (SN) observations during astronomical twilight b
 - **Strategy**: hybrid priority scheme ("quick color → escalate" or light-curve depth), batching by the first filter, and greedy routing to minimize combined slew and filter-change cost.
 - **Guard spacing**: a minimum inter-exposure spacing of 15 s is enforced. Readout overlaps with slewing, so the natural inter-visit gap is max(slew, readout) + cross-filter-change. If natural overheads are shorter, idle guard time is inserted before the next exposure. Guard time is accounted for prior to window cap checks and reported in per-row and per-window summaries.
 
+### Cadence constraint (per-filter)
+
+- Revisit spacing is enforced **per filter**, not per SN.
+- A same-band revisit is blocked until `cadence_days_target - cadence_jitter_days` days have
+  elapsed since that band was last observed.
+- First-time observations in a band always pass the gate, enabling quick colors.
+- A Gaussian “due-soon” bonus nudges bands whose last visit is near the target cadence
+  without hard-blocking other filters.
+- Nightly summaries report per-filter cadence compliance via
+  `cad_median_abs_err_by_filter_csv` and `cad_within_pct_by_filter_csv`, with overall
+  aggregates `cad_median_abs_err_all_d` and `cad_within_pct_all`.
+
 ### Outputs
 
 - Per-SN plan CSV (one row per scheduled visit). Represents the **best-in-theory** schedule keyed to each target's `best_time_utc`; times may overlap across different SNe and do not reflect the serialized on-sky order.

--- a/notebook/TwilightPlanner_Modular_Notebook.ipynb
+++ b/notebook/TwilightPlanner_Modular_Notebook.ipynb
@@ -29,10 +29,9 @@
     "# --- Imports and path setup ---\n",
     "import sys\n",
     "import os\n",
-    "import pandas as pd\n",
     "\n",
     "# Ensure local package is importable\n",
-    "sys.path.append('./')\n",
+    "sys.path.append(\"./\")\n",
     "\n",
     "from twilight_planner_pkg.config import PlannerConfig\n",
     "from twilight_planner_pkg.scheduler import plan_twilight_range_with_caps\n",
@@ -43,7 +42,7 @@
     "os.makedirs(OUTDIR, exist_ok=True)\n",
     "\n",
     "print(\"CSV exists:\", os.path.exists(CSV_PATH))\n",
-    "print(\"Output dir:\", OUTDIR)\n"
+    "print(\"Output dir:\", OUTDIR)"
    ],
    "outputs": [
     {
@@ -83,7 +82,7 @@
     "\n",
     "# Date range (UTC)\n",
     "START_DATE = \"2024-01-01\"\n",
-    "END_DATE   = \"2024-01-03\"\n",
+    "END_DATE = \"2024-01-03\"\n",
     "\n",
     "# -- Site --\n",
     "LAT_DEG = -30.2446\n",
@@ -92,6 +91,9 @@
     "\n",
     "# -- Visibility --\n",
     "MIN_ALT_DEG = 20.0\n",
+    "TWILIGHT_SUN_ALT_MIN_DEG = -15.0  # minimum altitude for twilight\n",
+    "TWILIGHT_SUN_ALT_MAX_DEG = -5.0  # maximum altitude for twilight\n",
+    "\n",
     "\n",
     "# -- Filters and hardware --\n",
     "FILTERS = [\"g\", \"r\", \"i\", \"z\"]\n",
@@ -99,9 +101,21 @@
     "FILTER_CHANGE_S = 120.0\n",
     "READOUT_S = 2.0\n",
     "FILTER_CHANGE_TIME_S = None  # legacy alias\n",
-    "READOUT_TIME_S = None        # legacy alias\n",
-    "EXPOSURE_BY_FILTER = {\"g\":5.0, \"r\":5.0, \"i\":5.0, \"z\":5.0}\n",
-    "MAX_FILTERS_PER_VISIT = 1\n",
+    "READOUT_TIME_S = None  # legacy alias\n",
+    "INTER_EXPOSURE_MIN_S = 15.0\n",
+    "EXPOSURE_BY_FILTER = {\"g\": 5.0, \"r\": 5.0, \"i\": 5.0, \"z\": 5.0}\n",
+    "# NEW — cadence knobs\n",
+    "CADENCE_ENABLE = True\n",
+    "CADENCE_PER_FILTER = True\n",
+    "CADENCE_DAYS_TARGET = 3.0\n",
+    "CADENCE_JITTER_DAYS = 0.25\n",
+    "CADENCE_DAYS_TOLERANCE = 0.5\n",
+    "CADENCE_BONUS_SIGMA_DAYS = 0.5\n",
+    "CADENCE_BONUS_WEIGHT = 0.25\n",
+    "\n",
+    "# Allow colors in one visit (if you want them)\n",
+    "MAX_FILTERS_PER_VISIT = 3  # was 1\n",
+    "ALLOW_FILTER_CHANGES_IN_TWILIGHT = True  # was False\n",
     "START_FILTER = FILTERS[0]\n",
     "SUN_ALT_POLICY = [\n",
     "    (-18.0, -15.0, [\"y\", \"z\", \"i\"]),\n",
@@ -117,7 +131,12 @@
     "\n",
     "# -- Moon --\n",
     "MIN_MOON_SEP_BY_FILTER = {\n",
-    "    \"u\":80.0, \"g\":50.0, \"r\":35.0, \"i\":30.0, \"z\":25.0, \"y\":20.0\n",
+    "    \"u\": 80.0,\n",
+    "    \"g\": 50.0,\n",
+    "    \"r\": 35.0,\n",
+    "    \"i\": 30.0,\n",
+    "    \"z\": 25.0,\n",
+    "    \"y\": 20.0,\n",
     "}\n",
     "REQUIRE_SINGLE_TIME_FOR_ALL = True\n",
     "\n",
@@ -157,7 +176,13 @@
     "\n",
     "# -- Miscellaneous --\n",
     "TYPICAL_DAYS_BY_TYPE = {\n",
-    "    \"Ia\":70, \"II-P\":100, \"II-L\":70, \"IIn\":120, \"IIb\":70, \"Ib\":60, \"Ic\":60,\n",
+    "    \"Ia\": 70,\n",
+    "    \"II-P\": 100,\n",
+    "    \"II-L\": 70,\n",
+    "    \"IIn\": 120,\n",
+    "    \"IIb\": 70,\n",
+    "    \"Ib\": 60,\n",
+    "    \"Ic\": 60,\n",
     "}\n",
     "DEFAULT_TYPICAL_DAYS = 60\n",
     "RA_COL = None\n",
@@ -165,18 +190,22 @@
     "DISC_COL = None\n",
     "NAME_COL = None\n",
     "TYPE_COL = None\n",
-    "ALLOW_FILTER_CHANGES_IN_TWILIGHT = False\n",
     "\n",
     "# Assemble the configuration object with all parameters exposed\n",
     "cfg = PlannerConfig(\n",
-    "    lat_deg=LAT_DEG, lon_deg=LON_DEG, height_m=HEIGHT_M,\n",
+    "    lat_deg=LAT_DEG,\n",
+    "    lon_deg=LON_DEG,\n",
+    "    height_m=HEIGHT_M,\n",
     "    min_alt_deg=MIN_ALT_DEG,\n",
+    "    twilight_sun_alt_min_deg=TWILIGHT_SUN_ALT_MIN_DEG,\n",
+    "    twilight_sun_alt_max_deg=TWILIGHT_SUN_ALT_MAX_DEG,\n",
     "    filters=FILTERS,\n",
     "    carousel_capacity=CAROUSEL_CAPACITY,\n",
     "    filter_change_s=FILTER_CHANGE_S,\n",
     "    readout_s=READOUT_S,\n",
     "    filter_change_time_s=FILTER_CHANGE_TIME_S,\n",
     "    readout_time_s=READOUT_TIME_S,\n",
+    "    inter_exposure_min_s=INTER_EXPOSURE_MIN_S,\n",
     "    exposure_by_filter=EXPOSURE_BY_FILTER,\n",
     "    max_filters_per_visit=MAX_FILTERS_PER_VISIT,\n",
     "    start_filter=START_FILTER,\n",
@@ -192,6 +221,13 @@
     "    evening_cap_s=EVENING_CAP_S,\n",
     "    twilight_step_min=TWILIGHT_STEP_MIN,\n",
     "    max_sn_per_night=MAX_SN_PER_NIGHT,\n",
+    "    cadence_enable=CADENCE_ENABLE,\n",
+    "    cadence_per_filter=CADENCE_PER_FILTER,\n",
+    "    cadence_days_target=CADENCE_DAYS_TARGET,\n",
+    "    cadence_jitter_days=CADENCE_JITTER_DAYS,\n",
+    "    cadence_days_tolerance=CADENCE_DAYS_TOLERANCE,\n",
+    "    cadence_bonus_sigma_days=CADENCE_BONUS_SIGMA_DAYS,\n",
+    "    cadence_bonus_weight=CADENCE_BONUS_WEIGHT,\n",
     "    hybrid_detections=HYBRID_DETECTIONS,\n",
     "    hybrid_exposure_s=HYBRID_EXPOSURE,\n",
     "    lc_detections=LC_DETECTIONS,\n",
@@ -215,12 +251,15 @@
     "    simlib_psf_unit=SIMLIB_PSF_UNIT,\n",
     "    typical_days_by_type=TYPICAL_DAYS_BY_TYPE,\n",
     "    default_typical_days=DEFAULT_TYPICAL_DAYS,\n",
-    "    ra_col=RA_COL, dec_col=DEC_COL, disc_col=DISC_COL,\n",
-    "    name_col=NAME_COL, type_col=TYPE_COL,\n",
+    "    ra_col=RA_COL,\n",
+    "    dec_col=DEC_COL,\n",
+    "    disc_col=DISC_COL,\n",
+    "    name_col=NAME_COL,\n",
+    "    type_col=TYPE_COL,\n",
     "    allow_filter_changes_in_twilight=ALLOW_FILTER_CHANGES_IN_TWILIGHT,\n",
     ")\n",
     "\n",
-    "cfg\n"
+    "cfg"
    ],
    "outputs": [
     {
@@ -272,7 +311,7 @@
     ")\n",
     "\n",
     "print(\"Per-SN rows:\", len(perSN_df), \"  Nights summary rows:\", len(nights_df))\n",
-    "perSN_df.head(10)\n"
+    "perSN_df.head(10)"
    ],
    "outputs": [
     {
@@ -578,9 +617,8 @@
     }
    },
    "source": [
-    "\n",
     "# Show the nightly summary\n",
-    "nights_df\n"
+    "nights_df"
    ],
    "outputs": [
     {
@@ -748,10 +786,11 @@
     }
    },
    "source": [
-    "import glob, os, pandas as pd\n",
+    "import glob\n",
+    "import os\n",
     "\n",
     "files = sorted(glob.glob(os.path.join(OUTDIR, \"lsst_twilight_*.csv\")))\n",
-    "files\n"
+    "files"
    ],
    "outputs": [
     {

--- a/twilight_planner_pkg/README.md
+++ b/twilight_planner_pkg/README.md
@@ -46,6 +46,18 @@ python -m twilight_planner_pkg.main --csv your.csv --out results \
    - Else: drop priority (reallocate time)
 3. **LSST‑only light curves** — pursue a full LC for every SN (≥5 detections or ≥300 s across ≥2 filters)
 
+### Cadence constraint (per-filter)
+
+- Revisit spacing is enforced **per filter**, not per supernova.
+- A same-band revisit is blocked until `cadence_days_target - cadence_jitter_days` days have
+  elapsed since that band was last observed.
+- First-time observations in a band always pass the gate, enabling quick colors.
+- A Gaussian “due-soon” bonus nudges bands whose last visit is near the target cadence
+  without hard-blocking other filters.
+- Nightly summaries report per-filter cadence compliance via
+  `cad_median_abs_err_by_filter_csv` and `cad_within_pct_by_filter_csv`, with overall
+  aggregates `cad_median_abs_err_all_d` and `cad_within_pct_all`.
+
 ---
 
 ## Notebook Example

--- a/twilight_planner_pkg/config.py
+++ b/twilight_planner_pkg/config.py
@@ -105,6 +105,31 @@ class PlannerConfig:
     lc_exposure_s: float = 300.0
     priority_strategy: str = "hybrid"
 
+    # -- Cadence ----------------------------------------------------------
+    cadence_enable: bool = True
+    """Enable cadence gating and bonus calculations."""
+
+    cadence_per_filter: bool = True
+    """If ``True``, track cadence separately for each filter."""
+
+    cadence_days_target: float = 3.0
+    """Target days between revisits in a given filter."""
+
+    cadence_jitter_days: float = 0.25
+    """Early revisit allowance below target days."""
+
+    cadence_days_tolerance: float = 0.5
+    """Tolerance window for cadence KPI calculations."""
+
+    cadence_bonus_sigma_days: float = 0.5
+    """Gaussian width (days) for the due-soon bonus."""
+
+    cadence_bonus_weight: float = 0.25
+    """Weight applied to the cadence bonus when ordering filters."""
+
+    cadence_first_epoch_bonus_weight: float = 0.0
+    """Bonus for a never-before-seen filter in cadence_bonus (0.0 = none)."""
+
     # -- Photometry / sky --------------------------------------------------
     pixel_scale_arcsec: float = 0.2
     zpt1s: Dict[str, float] | None = None

--- a/twilight_planner_pkg/tests/test_cadence_bonus_first_epoch.py
+++ b/twilight_planner_pkg/tests/test_cadence_bonus_first_epoch.py
@@ -1,0 +1,25 @@
+from twilight_planner_pkg.priority import PriorityTracker
+
+
+def test_first_epoch_bonus_default_zero():
+    t = PriorityTracker()
+    b0 = t.cadence_bonus(
+        "S",
+        "r",
+        now_mjd=1.0,
+        target_d=3.0,
+        sigma_d=0.5,
+        weight=0.25,
+        first_epoch_weight=0.0,
+    )
+    assert b0 == 0.0
+    b1 = t.cadence_bonus(
+        "S",
+        "r",
+        now_mjd=1.0,
+        target_d=3.0,
+        sigma_d=0.5,
+        weight=0.25,
+        first_epoch_weight=0.05,
+    )
+    assert 0.0 < b1 <= 0.25

--- a/twilight_planner_pkg/tests/test_cadence_per_filter.py
+++ b/twilight_planner_pkg/tests/test_cadence_per_filter.py
@@ -1,0 +1,102 @@
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pandas as pd
+
+from twilight_planner_pkg.config import PlannerConfig
+from twilight_planner_pkg.priority import PriorityTracker
+from twilight_planner_pkg.scheduler import plan_twilight_range_with_caps
+
+
+def _subset_csv(src: Path, out: Path) -> Path:
+    df = pd.read_csv(src).head(1)
+    df.to_csv(out, index=False)
+    return out
+
+
+def _mock_windows(date_local, loc=None, min_sun_alt_deg=-18.0, max_sun_alt_deg=0.0):
+    start = datetime(
+        date_local.year, date_local.month, date_local.day, 5, 0, 0, tzinfo=timezone.utc
+    )
+    end = start + timedelta(minutes=30)
+    return [
+        {"start": start, "end": end, "label": "morning", "night_date": date_local},
+    ]
+
+
+def _mock_best_time(sc, window, loc, step_min, min_alt_deg, min_moon_sep_deg):
+    start, _ = window
+    return 50.0, start + timedelta(minutes=5), 0.0, 0.0, 180.0
+
+
+def test_first_epoch_multi_band_allowed():
+    t = PriorityTracker()
+    t.record_detection("SN1", 10.0, ["r", "g"], mjd=1.0)
+    assert set(t.history["SN1"].last_mjd_by_filter.keys()) == {"r", "g"}
+
+
+def test_cadence_blocks_same_filter_allows_other():
+    t = PriorityTracker()
+    t.record_detection("SN1", 10.0, ["r"], mjd=1.0)
+    assert not t.cadence_gate("SN1", "r", 1.5, 3.0, 0.25)
+    assert t.cadence_gate("SN1", "g", 1.5, 3.0, 0.25)
+
+
+def test_simlib_uses_visit_mjd(tmp_path, monkeypatch):
+    data_path = (
+        Path(__file__).resolve().parents[2] / "data" / "ATLAS_2021_to25_cleaned.csv"
+    )
+    csv_path = _subset_csv(data_path, tmp_path / "subset.csv")
+
+    from twilight_planner_pkg import scheduler
+
+    monkeypatch.setattr(scheduler, "twilight_windows_for_local_night", _mock_windows)
+    monkeypatch.setattr(scheduler, "_best_time_with_moon", _mock_best_time)
+    monkeypatch.setattr(scheduler, "great_circle_sep_deg", lambda *a, **k: 0.0)
+    monkeypatch.setattr(
+        scheduler,
+        "RubinSkyProvider",
+        lambda: scheduler.SimpleSkyProvider(scheduler.SkyModelConfig()),
+    )
+
+    simlib_path = tmp_path / "plan.SIMLIB"
+
+    cfg = PlannerConfig(
+        lat_deg=0.0,
+        lon_deg=0.0,
+        height_m=0.0,
+        filters=["r"],
+        exposure_by_filter={"r": 5.0},
+        readout_s=1.0,
+        filter_change_s=0.0,
+        morning_cap_s=50.0,
+        evening_cap_s=50.0,
+        max_sn_per_night=1,
+        per_sn_cap_s=20.0,
+        min_moon_sep_by_filter={"r": 0.0},
+        require_single_time_for_all_filters=False,
+        min_alt_deg=0.0,
+        twilight_step_min=1,
+        allow_filter_changes_in_twilight=True,
+        simlib_out=str(simlib_path),
+    )
+
+    pernight_df, _ = plan_twilight_range_with_caps(
+        csv_path=str(csv_path),
+        outdir=str(tmp_path),
+        start_date="2025-07-30",
+        end_date="2025-07-30",
+        cfg=cfg,
+        verbose=False,
+    )
+
+    mjd_seq = float(
+        pernight_df["visit_start_utc"]
+        .apply(lambda x: pd.Timestamp(x, tz="UTC"))
+        .apply(lambda t: t.to_julian_date() - 2400000.5)
+        .iloc[0]
+    )
+    lines = simlib_path.read_text().strip().splitlines()
+    s_line = next(line for line in lines if line.startswith("S:"))
+    mjd_simlib = float(s_line.split()[1])
+    assert abs(mjd_seq - mjd_simlib) < 1e-4

--- a/twilight_planner_pkg/tests/test_scheduler.py
+++ b/twilight_planner_pkg/tests/test_scheduler.py
@@ -128,6 +128,7 @@ def test_plan_twilight_range_basic(tmp_path, monkeypatch):
         "Dec_deg",
         "best_twilight_time_utc",
         "sn_end_utc",
+        "visit_start_utc",
         "filter",
         "t_exp_s",
         "airmass",
@@ -141,6 +142,9 @@ def test_plan_twilight_range_basic(tmp_path, monkeypatch):
         "saturation_guard_applied",
         "warn_nonlinear",
         "priority_score",
+        "cadence_days_since",
+        "cadence_target_d",
+        "cadence_gate_passed",
     }
     assert expected_cols.issubset(pernight_df.columns)
 
@@ -148,7 +152,7 @@ def test_plan_twilight_range_basic(tmp_path, monkeypatch):
 
     # End time equals start time plus total visit duration
     mask = pernight_df["total_time_s"] > 0
-    starts = pd.to_datetime(pernight_df.loc[mask, "best_twilight_time_utc"], utc=True)
+    starts = pd.to_datetime(pernight_df.loc[mask, "visit_start_utc"], utc=True)
     ends = pd.to_datetime(pernight_df.loc[mask, "sn_end_utc"], utc=True)
     durations = pernight_df.loc[mask, "total_time_s"]
     assert ((ends - starts).dt.total_seconds().round(3) == durations.round(3)).all()


### PR DESCRIPTION
## Goal
Implement configurable first-epoch cadence bonus and remove duplicate window-state assignments.

## Plan Stage
Stage 4: per-filter cadence

## Changes
- add `cadence_first_epoch_bonus_weight` to `PlannerConfig`
- allow `cadence_bonus` to apply configurable weight for never-seen filters
- update scheduler to set window state once using the last filter
- regression test for default/weighted first-epoch bonus

## Assumptions & Units
- MJDs represent visit start times (days)
- Cadence bonuses are unitless weights

## Tests
- `ruff check twilight_planner_pkg/config.py twilight_planner_pkg/priority.py twilight_planner_pkg/scheduler.py twilight_planner_pkg/tests/test_cadence_bonus_first_epoch.py`
- `black --check twilight_planner_pkg/config.py twilight_planner_pkg/priority.py twilight_planner_pkg/scheduler.py twilight_planner_pkg/tests/test_cadence_bonus_first_epoch.py`
- `isort --profile black --check-only twilight_planner_pkg/config.py twilight_planner_pkg/priority.py twilight_planner_pkg/scheduler.py twilight_planner_pkg/tests/test_cadence_bonus_first_epoch.py`
- `mypy twilight_planner_pkg` *(fails: missing stubs for pandas/astropy)*
- `pytest -q`

## SIMLIB Impact
No schema or value changes.

## Risk & Rollback
Low risk; revert commits to restore prior behavior.

------
https://chatgpt.com/codex/tasks/task_e_68a1a62b4c948321b73f8e4188c89281