### PR TITLE
fix cadence gating and add defer queue

### DIFF
--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -7,6 +7,7 @@ This plan tracks incremental, testable stages for the twilight planner and the s
 You’re right—cadence should be enforced per **filter**, not per-SN. Here’s a clean way to bolt that in without fighting your existing flow.
 
 # Revised Stage 4 (per-filter cadence)
+**Status**: Complete
 
 * Enforce spacing only for the **same filter**: require `days_since_last(filter) ≥ cadence_days_target - cadence_jitter_days`.
 * Allow different filters at the same epoch (so same-night g,r,i is fine).

--- a/twilight_planner_pkg/scheduler.py
+++ b/twilight_planner_pkg/scheduler.py
@@ -360,6 +360,15 @@ def plan_twilight_range_with_caps(
                     cfg.exposure_by_filter = override_exp
                     break
 
+            cad_on = getattr(cfg, "cadence_enable", True) and getattr(
+                cfg, "cadence_per_filter", True
+            )
+            cad_tgt = getattr(cfg, "cadence_days_target", 3.0)
+            cad_jit = getattr(cfg, "cadence_jitter_days", 0.25)
+            cad_sig = getattr(cfg, "cadence_bonus_sigma_days", 0.5)
+            cad_wt = getattr(cfg, "cadence_bonus_weight", 0.25)
+            cad_first = getattr(cfg, "cadence_first_epoch_bonus_weight", 0.0)
+
             candidates = []
             for _, row in group.iterrows():
                 allowed = allowed_filters_for_window(
@@ -385,29 +394,14 @@ def plan_twilight_range_with_caps(
                     )
                     for f in allowed
                 }
-                allowed = [f for f in allowed if moon_sep_ok.get(f, False)]
-                if getattr(cfg, "cadence_enable", True) and getattr(
-                    cfg, "cadence_per_filter", True
-                ):
-                    now_mjd_for_gate = Time(current_time_utc).mjd
-                    allowed = [
-                        f
-                        for f in allowed
-                        if tracker.cadence_gate(
-                            row["Name"],
-                            f,
-                            now_mjd_for_gate,
-                            getattr(cfg, "cadence_days_target", 3.0),
-                            getattr(cfg, "cadence_jitter_days", 0.25),
-                        )
-                    ]
-                if not allowed:
+                policy_allowed = [f for f in allowed if moon_sep_ok.get(f, False)]
+                if not policy_allowed:
                     continue
                 first = pick_first_filter_for_target(
                     row["Name"],
                     row.get("SN_type_raw"),
                     tracker,
-                    allowed,
+                    policy_allowed,
                     cfg,
                     sun_alt_deg=sun_alt,
                     moon_sep_ok=moon_sep_ok,
@@ -416,23 +410,23 @@ def plan_twilight_range_with_caps(
                 )
                 if first is None:
                     continue
-                if getattr(cfg, "cadence_enable", True) and getattr(
-                    cfg, "cadence_per_filter", True
-                ):
+                now_mjd_for_bonus = Time(current_time_utc).mjd
+                if cad_on:
                     rest = sorted(
-                        [f for f in allowed if f != first],
+                        [f for f in policy_allowed if f != first],
                         key=lambda f: tracker.cadence_bonus(
                             row["Name"],
                             f,
-                            now_mjd_for_gate,
-                            getattr(cfg, "cadence_days_target", 3.0),
-                            getattr(cfg, "cadence_bonus_sigma_days", 0.5),
-                            getattr(cfg, "cadence_bonus_weight", 0.25),
+                            now_mjd_for_bonus,
+                            cad_tgt,
+                            cad_sig,
+                            weight=cad_wt,
+                            first_epoch_weight=cad_first,
                         ),
                         reverse=True,
                     )
                 else:
-                    rest = [f for f in allowed if f != first]
+                    rest = [f for f in policy_allowed if f != first]
                 cand = {
                     "Name": row["Name"],
                     "RA_deg": row["RA_deg"],
@@ -443,6 +437,7 @@ def plan_twilight_range_with_caps(
                     "first_filter": first,
                     "sn_type": row.get("SN_type_raw"),
                     "allowed": [first] + rest,
+                    "policy_allowed": policy_allowed,
                     "moon_sep_ok": moon_sep_ok,
                     "moon_sep": float(row["_moon_sep"]),
                 }
@@ -469,29 +464,332 @@ def plan_twilight_range_with_caps(
             filters_used_set: set[str] = set()
             state = current_filter_by_window.get(idx_w)
 
+            deferred: list[dict] = []
+
             # ---- NEW: per-window running clock (UTC) for true order ----
             current_time_utc = pd.Timestamp(win["start"]).tz_convert("UTC")
             order_in_window = 0
+
+            def _attempt_schedule(t: dict, allow_defer: bool = True) -> bool:
+                nonlocal window_sum, prev, internal_changes, window_filter_change_s
+                nonlocal state, window_slew_times, window_airmasses, window_skymags
+                nonlocal filters_used_set, current_time_utc, order_in_window, libid_counter
+                sep = (
+                    0.0
+                    if prev is None
+                    else great_circle_sep_deg(
+                        prev["RA_deg"], prev["Dec_deg"], t["RA_deg"], t["Dec_deg"]
+                    )
+                )
+                cfg.current_mag_by_filter = mag_lookup.get(t["Name"])
+                cfg.current_alt_deg = t["max_alt_deg"]
+                cfg.current_mjd = (
+                    Time(t["best_time_utc"]).mjd
+                    if isinstance(t["best_time_utc"], (datetime, pd.Timestamp))
+                    else None
+                )
+                now_mjd = Time(current_time_utc).mjd
+                if cad_on:
+                    gated = [
+                        f
+                        for f in t["policy_allowed"]
+                        if tracker.cadence_gate(t["Name"], f, now_mjd, cad_tgt, cad_jit)
+                    ]
+                    if not gated:
+                        if allow_defer:
+                            deferred.append(t)
+                        return False
+
+                    def _bonus(f: str) -> float:
+                        return tracker.cadence_bonus(
+                            t["Name"],
+                            f,
+                            now_mjd,
+                            cad_tgt,
+                            cad_sig,
+                            weight=cad_wt,
+                            first_epoch_weight=cad_first,
+                        )
+
+                    first = (
+                        t["first_filter"]
+                        if t["first_filter"] in gated
+                        else max(gated, key=_bonus)
+                    )
+                    rest = sorted(
+                        [f for f in gated if f != first], key=_bonus, reverse=True
+                    )
+                    filters_pref = ([first] + rest)[: int(cfg.max_filters_per_visit)]
+                else:
+                    filters_pref = (
+                        [t["first_filter"]]
+                        + [f for f in t["allowed"] if f != t["first_filter"]]
+                    )[: int(cfg.max_filters_per_visit)]
+                filters_used, timing = choose_filters_with_cap(
+                    filters_pref,
+                    sep,
+                    cfg.per_sn_cap_s,
+                    cfg,
+                    current_filter=state,
+                    max_filters_per_visit=cfg.max_filters_per_visit,
+                )
+                if not filters_used:
+                    return False
+                natural_gap_first = max(timing["slew_s"], cfg.readout_s) + timing.get(
+                    "cross_filter_change_s", 0.0
+                )
+                guard_first_s = (
+                    0.0
+                    if window_sum == 0.0
+                    else max(0.0, cfg.inter_exposure_min_s - natural_gap_first)
+                )
+                internal_gap = cfg.readout_s + (
+                    cfg.filter_change_s if len(filters_used) > 1 else 0.0
+                )
+                guard_internal_per = max(0.0, cfg.inter_exposure_min_s - internal_gap)
+                guard_internal_total = guard_internal_per * max(
+                    0, len(filters_used) - 1
+                )
+                guard_s = guard_first_s + guard_internal_total
+                elapsed_overhead = (
+                    max(timing["slew_s"], cfg.readout_s)
+                    + timing.get("filter_changes_s", 0.0)
+                    + timing.get("cross_filter_change_s", 0.0)
+                )
+                total_with_guard = elapsed_overhead + timing["exposure_s"] + guard_s
+                if window_sum + total_with_guard > cap_s:
+                    return False
+                window_sum += total_with_guard
+                window_filter_change_s += timing.get(
+                    "filter_changes_s", 0.0
+                ) + timing.get("cross_filter_change_s", 0.0)
+                timing["total_s"] = total_with_guard
+                timing["guard_s"] = guard_s
+                timing["elapsed_overhead_s"] = elapsed_overhead
+                timing["guard_first_s"] = guard_first_s
+                timing["guard_internal_s"] = guard_internal_total
+
+                preferred_utc = (
+                    pd.Timestamp(t["best_time_utc"]).tz_convert("UTC")
+                    if isinstance(t["best_time_utc"], pd.Timestamp)
+                    else pd.Timestamp(t["best_time_utc"]).tz_localize("UTC")
+                )
+                sn_start_utc = current_time_utc
+                sn_end_utc = sn_start_utc + pd.to_timedelta(timing["total_s"], unit="s")
+                visit_mjd = Time(sn_start_utc).mjd
+
+                current_time_utc = sn_end_utc
+                order_in_window += 1
+
+                sequence_rows.append(
+                    {
+                        "date": day.date().isoformat(),
+                        "twilight_window": window_label_out,
+                        "order_in_window": int(order_in_window),
+                        "SN": t["Name"],
+                        "RA_deg": round(t["RA_deg"], 6),
+                        "Dec_deg": round(t["Dec_deg"], 6),
+                        "filters_used_csv": ",".join(filters_used),
+                        "preferred_best_utc": preferred_utc.isoformat(),
+                        "sn_start_utc": sn_start_utc.isoformat(),
+                        "sn_end_utc": sn_end_utc.isoformat(),
+                        "total_time_s": round(timing.get("total_s", 0.0), 2),
+                        "slew_s": round(timing.get("slew_s", 0.0), 2),
+                        "readout_s": round(timing.get("readout_s", 0.0), 2),
+                        "filter_changes_s": round(
+                            timing.get("filter_changes_s", 0.0), 2
+                        ),
+                        "cross_filter_change_s": round(
+                            timing.get("cross_filter_change_s", 0.0), 2
+                        ),
+                        "guard_s": round(timing.get("guard_s", 0.0), 2),
+                        "elapsed_overhead_s": round(
+                            timing.get("elapsed_overhead_s", 0.0), 2
+                        ),
+                    }
+                )
+
+                epochs = []
+                air = 0.0
+                for f in filters_used:
+                    exp_s = timing.get("exp_times", {}).get(
+                        f, cfg.exposure_by_filter.get(f, 0.0)
+                    )
+                    flags = timing.get("flags_by_filter", {}).get(f, set())
+                    alt_deg = float(t["max_alt_deg"])
+                    air = airmass_from_alt_deg(alt_deg)
+                    mjd = visit_mjd
+                    if sky_provider:
+                        sky_mag = sky_provider.sky_mag(
+                            mjd,
+                            t["RA_deg"],
+                            t["Dec_deg"],
+                            f,
+                            airmass_from_alt_deg(alt_deg),
+                        )
+                    else:
+                        sky_mag = sky_mag_arcsec2(f, sky_cfg)
+                    eph = compute_epoch_photom(f, exp_s, alt_deg, sky_mag, phot_cfg)
+                    window_skymags.append(sky_mag)
+                    if writer:
+                        epochs.append(
+                            {
+                                "mjd": mjd,
+                                "band": f,
+                                "gain": eph.GAIN,
+                                "rdnoise": eph.RDNOISE,
+                                "skysig": eph.SKYSIG,
+                                "nea": eph.NEA_pix,
+                                "zpavg": eph.ZPTAVG,
+                                "zperr": eph.ZPTERR,
+                                "mag": -99.0,
+                            }
+                        )
+                    start_utc = sn_start_utc
+                    total_s = round(timing["total_s"], 2)
+                    end_utc = sn_end_utc
+                    days_since = tracker.days_since(t["Name"], f, visit_mjd)
+                    gate_passed = (
+                        tracker.cadence_gate(t["Name"], f, visit_mjd, cad_tgt, cad_jit)
+                        if cad_on
+                        else True
+                    )
+                    best_start_utc = (
+                        pd.Timestamp(t["best_time_utc"]).tz_convert("UTC")
+                        if isinstance(t["best_time_utc"], pd.Timestamp)
+                        else pd.Timestamp(t["best_time_utc"]).tz_localize("UTC")
+                    )
+                    row = {
+                        "date": day.date().isoformat(),
+                        "twilight_window": window_label_out,
+                        "SN": t["Name"],
+                        "RA_deg": round(t["RA_deg"], 6),
+                        "Dec_deg": round(t["Dec_deg"], 6),
+                        "best_twilight_time_utc": best_start_utc.isoformat(),
+                        "visit_start_utc": start_utc.isoformat(),
+                        "sn_end_utc": end_utc.isoformat(),
+                        "filter": f,
+                        "t_exp_s": round(exp_s, 1),
+                        "airmass": round(air, 3),
+                        "alt_deg": round(alt_deg, 2),
+                        "sky_mag_arcsec2": round(sky_mag, 2),
+                        "moon_sep": round(float(t.get("moon_sep", np.nan)), 2),
+                        "ZPT": round(eph.ZPTAVG, 3),
+                        "SKYSIG": round(eph.SKYSIG, 3),
+                        "NEA_pix": round(eph.NEA_pix, 2),
+                        "RDNOISE": round(eph.RDNOISE, 2),
+                        "GAIN": round(eph.GAIN, 2),
+                        "saturation_guard_applied": "sat_guard" in flags,
+                        "warn_nonlinear": "warn_nonlinear" in flags,
+                        "priority_score": round(float(t["priority_score"]), 2),
+                        "cadence_days_since": (
+                            round(days_since, 3) if days_since is not None else np.nan
+                        ),
+                        "cadence_target_d": cad_tgt,
+                        "cadence_gate_passed": bool(gate_passed),
+                        "slew_s": (
+                            round(timing["slew_s"], 2) if f == filters_used[0] else 0.0
+                        ),
+                        "cross_filter_change_s": (
+                            round(timing.get("cross_filter_change_s", 0.0), 2)
+                            if f == filters_used[0]
+                            else 0.0
+                        ),
+                        "filter_changes_s": (
+                            round(timing.get("filter_changes_s", 0.0), 2)
+                            if f == filters_used[0]
+                            else 0.0
+                        ),
+                        "readout_s": (
+                            round(timing["readout_s"], 2)
+                            if f == filters_used[0]
+                            else 0.0
+                        ),
+                        "exposure_s": (
+                            round(timing["exposure_s"], 2)
+                            if f == filters_used[0]
+                            else 0.0
+                        ),
+                        "guard_s": (
+                            round(timing.get("guard_s", 0.0), 2)
+                            if f == filters_used[0]
+                            else 0.0
+                        ),
+                        "inter_exposure_guard_enforced": (
+                            bool(timing.get("guard_s", 0.0) > 0.0)
+                            if f == filters_used[0]
+                            else False
+                        ),
+                        "total_time_s": (total_s if f == filters_used[0] else 0.0),
+                        "elapsed_overhead_s": (
+                            round(timing.get("elapsed_overhead_s", 0.0), 2)
+                            if f == filters_used[0]
+                            else 0.0
+                        ),
+                    }
+                    pernight_rows.append(row)
+                if writer and epochs:
+                    writer.start_libid(
+                        libid_counter,
+                        t["RA_deg"],
+                        t["Dec_deg"],
+                        nobs=len(epochs),
+                        comment=t["Name"],
+                    )
+                    libid_counter += 1
+                    for epoch in epochs:
+                        writer.add_epoch(**epoch)
+                    writer.end_libid()
+                if filters_used:
+                    if state is not None and filters_used[0] != state:
+                        swap_count_by_window[idx_w] += 1
+                    state = filters_used[-1]
+                    current_filter_by_window[idx_w] = state
+                    filters_used_set.update(filters_used)
+                internal_changes += max(0, len(filters_used) - 1)
+                window_slew_times.append(timing["slew_s"])
+                window_airmasses.append(air)
+                prev = t
+                tracker.record_detection(
+                    t["Name"], timing["exposure_s"], filters_used, mjd=visit_mjd
+                )
+                return True
 
             for filt in batch_order:
                 batch = [c for c in candidates if c["first_filter"] == filt]
                 while batch:
                     # select next target based on filter-aware cost
                     costs: List[float] = []
-                    first_choices: List[str] = []
                     for t in batch:
-                        first_tmp = pick_first_filter_for_target(
-                            t["Name"],
-                            t.get("sn_type"),
-                            tracker,
-                            t["allowed"],
-                            cfg,
-                            sun_alt_deg=sun_alt,
-                            moon_sep_ok=t["moon_sep_ok"],
-                            current_mag=mag_lookup.get(t["Name"]),
-                            current_filter=state,
-                        )
-                        first_choices.append(first_tmp)
+                        now_mjd_cost = Time(current_time_utc).mjd
+                        gated_for_cost = [
+                            f
+                            for f in t.get("policy_allowed", t["allowed"])
+                            if (not cad_on)
+                            or tracker.cadence_gate(
+                                t["Name"], f, now_mjd_cost, cad_tgt, cad_jit
+                            )
+                        ]
+                        if gated_for_cost:
+
+                            def _bonus_cost(f: str) -> float:
+                                return tracker.cadence_bonus(
+                                    t["Name"],
+                                    f,
+                                    now_mjd_cost,
+                                    cad_tgt,
+                                    cad_sig,
+                                    weight=cad_wt,
+                                    first_epoch_weight=cad_first,
+                                )
+
+                            first_tmp = (
+                                t["first_filter"]
+                                if t["first_filter"] in gated_for_cost
+                                else max(gated_for_cost, key=_bonus_cost)
+                            )
+                        else:
+                            first_tmp = None
                         sep = (
                             0.0
                             if prev is None
@@ -509,305 +807,23 @@ def plan_twilight_range_with_caps(
                             rate_deg_per_s=cfg.slew_rate_deg_per_s,
                             settle_s=cfg.slew_settle_s,
                         )
-                        if state is not None and state != first_tmp:
+                        if first_tmp is None:
+                            cost = 1e9
+                        elif state is not None and state != first_tmp:
                             cost += cfg.filter_change_s
                         costs.append(cost)
                     j = int(np.argmin(costs))
                     t = batch.pop(j)
-                    first = first_choices.pop(j)
-                    sep = (
-                        0.0
-                        if prev is None
-                        else great_circle_sep_deg(
-                            prev["RA_deg"], prev["Dec_deg"], t["RA_deg"], t["Dec_deg"]
-                        )
-                    )
-                    cfg.current_mag_by_filter = mag_lookup.get(t["Name"])
-                    cfg.current_alt_deg = t["max_alt_deg"]
-                    cfg.current_mjd = (
-                        Time(t["best_time_utc"]).mjd
-                        if isinstance(t["best_time_utc"], (datetime, pd.Timestamp))
-                        else None
-                    )
-                    filters_pref = [first] + [x for x in t["allowed"] if x != first]
-                    filters_used, timing = choose_filters_with_cap(
-                        filters_pref,
-                        sep,
-                        cfg.per_sn_cap_s,
-                        cfg,
-                        current_filter=state,
-                        max_filters_per_visit=cfg.max_filters_per_visit,
-                    )
-                    # Readout overlaps with slew. The time from end of previous
-                    # exposure to the start of this visit's first exposure is
-                    # max(slew, readout) plus any cross-target filter change that
-                    # cannot overlap with slew.
-                    natural_gap_first = max(
-                        timing["slew_s"], cfg.readout_s
-                    ) + timing.get("cross_filter_change_s", 0.0)
+                    _attempt_schedule(t)
 
-                    guard_first_s = (
-                        0.0
-                        if window_sum == 0.0
-                        else max(0.0, cfg.inter_exposure_min_s - natural_gap_first)
-                    )
-                    internal_gap = cfg.readout_s + (
-                        cfg.filter_change_s if len(filters_used) > 1 else 0.0
-                    )
-                    guard_internal_per = max(
-                        0.0, cfg.inter_exposure_min_s - internal_gap
-                    )
-                    guard_internal_total = guard_internal_per * max(
-                        0, len(filters_used) - 1
-                    )
-                    guard_s = guard_first_s + guard_internal_total
-                    elapsed_overhead = (
-                        max(timing["slew_s"], cfg.readout_s)
-                        + timing.get("filter_changes_s", 0.0)
-                        + timing.get("cross_filter_change_s", 0.0)
-                    )
-                    total_with_guard = elapsed_overhead + timing["exposure_s"] + guard_s
-                    if window_sum + total_with_guard > cap_s:
-                        continue
-                    window_sum += total_with_guard
-                    window_filter_change_s += timing.get(
-                        "filter_changes_s", 0.0
-                    ) + timing.get("cross_filter_change_s", 0.0)
-                    timing["total_s"] = total_with_guard
-                    timing["guard_s"] = guard_s
-                    timing["elapsed_overhead_s"] = elapsed_overhead
-                    timing["guard_first_s"] = guard_first_s
-                    timing["guard_internal_s"] = guard_internal_total
-
-                    # ---- NEW: true sequential scheduling (no overlap) ----
-                    preferred_utc = (
-                        pd.Timestamp(t["best_time_utc"]).tz_convert("UTC")
-                        if isinstance(t["best_time_utc"], pd.Timestamp)
-                        else pd.Timestamp(t["best_time_utc"]).tz_localize("UTC")
-                    )
-                    sn_start_utc = current_time_utc
-                    sn_end_utc = sn_start_utc + pd.to_timedelta(
-                        timing["total_s"], unit="s"
-                    )
-                    visit_mjd = Time(sn_start_utc).mjd
-
-                    # ---- RECHECK cadence at true visit start ----
-                    if getattr(cfg, "cadence_enable", True) and getattr(
-                        cfg, "cadence_per_filter", True
-                    ):
-                        gate_mjd = visit_mjd
-                        gated_now = [
-                            f
-                            for f in t["allowed"]
-                            if tracker.cadence_gate(
-                                t["Name"],
-                                f,
-                                gate_mjd,
-                                getattr(cfg, "cadence_days_target", 3.0),
-                                getattr(cfg, "cadence_jitter_days", 0.25),
-                            )
-                        ]
-                        if not gated_now:
-                            # nothing legal yet at this exact start time; skip this visit
-                            continue
-                        if t["allowed"][0] not in gated_now:
-                            # promote the next eligible filter; keep cadence-aware order
-                            t["allowed"] = gated_now
-
-                    # advance window clock and ordering index
-                    current_time_utc = sn_end_utc
-                    order_in_window += 1
-
-                    # ---- NEW: append a single true-order visit row ----
-                    sequence_rows.append(
-                        {
-                            "date": day.date().isoformat(),
-                            "twilight_window": window_label_out,
-                            "order_in_window": int(order_in_window),
-                            "SN": t["Name"],
-                            "RA_deg": round(t["RA_deg"], 6),
-                            "Dec_deg": round(t["Dec_deg"], 6),
-                            "filters_used_csv": ",".join(filters_used),
-                            # theoretical preference (for traceability; keep the old outputs as-is)
-                            "preferred_best_utc": preferred_utc.isoformat(),
-                            # true, serialized schedule (non-overlapping)
-                            "sn_start_utc": sn_start_utc.isoformat(),
-                            "sn_end_utc": sn_end_utc.isoformat(),
-                            # timing breakdown (optional but useful)
-                            "total_time_s": round(timing.get("total_s", 0.0), 2),
-                            "slew_s": round(timing.get("slew_s", 0.0), 2),
-                            "readout_s": round(timing.get("readout_s", 0.0), 2),
-                            "filter_changes_s": round(
-                                timing.get("filter_changes_s", 0.0), 2
-                            ),
-                            "cross_filter_change_s": round(
-                                timing.get("cross_filter_change_s", 0.0), 2
-                            ),
-                            "guard_s": round(timing.get("guard_s", 0.0), 2),
-                            "elapsed_overhead_s": round(
-                                timing.get("elapsed_overhead_s", 0.0), 2
-                            ),
-                        }
-                    )
-
-                    epochs = []
-                    for f in filters_used:
-                        exp_s = timing.get("exp_times", {}).get(
-                            f, cfg.exposure_by_filter.get(f, 0.0)
-                        )
-                        flags = timing.get("flags_by_filter", {}).get(f, set())
-                        alt_deg = float(t["max_alt_deg"])
-                        air = airmass_from_alt_deg(alt_deg)
-                        mjd = visit_mjd
-                        if sky_provider:
-                            sky_mag = sky_provider.sky_mag(
-                                mjd,
-                                t["RA_deg"],
-                                t["Dec_deg"],
-                                f,
-                                airmass_from_alt_deg(alt_deg),
-                            )
-                        else:
-                            sky_mag = sky_mag_arcsec2(f, sky_cfg)
-                        eph = compute_epoch_photom(f, exp_s, alt_deg, sky_mag, phot_cfg)
-                        window_skymags.append(sky_mag)
-                        if writer:
-                            epochs.append(
-                                {
-                                    "mjd": mjd,
-                                    "band": f,
-                                    "gain": eph.GAIN,
-                                    "rdnoise": eph.RDNOISE,
-                                    "skysig": eph.SKYSIG,
-                                    "nea": eph.NEA_pix,
-                                    "zpavg": eph.ZPTAVG,
-                                    "zperr": eph.ZPTERR,
-                                    "mag": -99.0,
-                                }
-                            )
-                        # Observation start and end times in UTC
-                        start_utc = sn_start_utc
-                        total_s = round(timing["total_s"], 2)
-                        end_utc = sn_end_utc
-                        days_since = tracker.days_since(t["Name"], f, visit_mjd)
-                        gate_passed = (
-                            tracker.cadence_gate(
-                                t["Name"],
-                                f,
-                                visit_mjd,
-                                getattr(cfg, "cadence_days_target", 3.0),
-                                getattr(cfg, "cadence_jitter_days", 0.25),
-                            )
-                            if getattr(cfg, "cadence_enable", True)
-                            and getattr(cfg, "cadence_per_filter", True)
-                            else True
-                        )
-                        best_start_utc = (
-                            pd.Timestamp(t["best_time_utc"]).tz_convert("UTC")
-                            if isinstance(t["best_time_utc"], pd.Timestamp)
-                            else pd.Timestamp(t["best_time_utc"]).tz_localize("UTC")
-                        )
-                        row = {
-                            "date": day.date().isoformat(),
-                            "twilight_window": window_label_out,
-                            "SN": t["Name"],
-                            "RA_deg": round(t["RA_deg"], 6),
-                            "Dec_deg": round(t["Dec_deg"], 6),
-                            "best_twilight_time_utc": best_start_utc.isoformat(),
-                            "visit_start_utc": start_utc.isoformat(),
-                            "sn_end_utc": end_utc.isoformat(),
-                            "filter": f,
-                            "t_exp_s": round(exp_s, 1),
-                            "airmass": round(air, 3),
-                            "alt_deg": round(alt_deg, 2),
-                            "sky_mag_arcsec2": round(sky_mag, 2),
-                            "moon_sep": round(float(t.get("moon_sep", np.nan)), 2),
-                            "ZPT": round(eph.ZPTAVG, 3),
-                            "SKYSIG": round(eph.SKYSIG, 3),
-                            "NEA_pix": round(eph.NEA_pix, 2),
-                            "RDNOISE": round(eph.RDNOISE, 2),
-                            "GAIN": round(eph.GAIN, 2),
-                            "saturation_guard_applied": "sat_guard" in flags,
-                            "warn_nonlinear": "warn_nonlinear" in flags,
-                            "priority_score": round(float(t["priority_score"]), 2),
-                            "cadence_days_since": (
-                                round(days_since, 3)
-                                if days_since is not None
-                                else np.nan
-                            ),
-                            "cadence_target_d": getattr(
-                                cfg, "cadence_days_target", 3.0
-                            ),
-                            "cadence_gate_passed": gate_passed,
-                            "slew_s": (
-                                round(timing["slew_s"], 2)
-                                if f == filters_used[0]
-                                else 0.0
-                            ),
-                            "cross_filter_change_s": (
-                                round(timing.get("cross_filter_change_s", 0.0), 2)
-                                if f == filters_used[0]
-                                else 0.0
-                            ),
-                            "filter_changes_s": (
-                                round(timing.get("filter_changes_s", 0.0), 2)
-                                if f == filters_used[0]
-                                else 0.0
-                            ),
-                            "readout_s": (
-                                round(timing["readout_s"], 2)
-                                if f == filters_used[0]
-                                else 0.0
-                            ),
-                            "exposure_s": (
-                                round(timing["exposure_s"], 2)
-                                if f == filters_used[0]
-                                else 0.0
-                            ),
-                            "guard_s": (
-                                round(timing.get("guard_s", 0.0), 2)
-                                if f == filters_used[0]
-                                else 0.0
-                            ),
-                            "inter_exposure_guard_enforced": (
-                                bool(timing.get("guard_s", 0.0) > 0.0)
-                                if f == filters_used[0]
-                                else False
-                            ),
-                            "total_time_s": (total_s if f == filters_used[0] else 0.0),
-                            "elapsed_overhead_s": (
-                                round(timing.get("elapsed_overhead_s", 0.0), 2)
-                                if f == filters_used[0]
-                                else 0.0
-                            ),
-                        }
-                        pernight_rows.append(row)
-
-                    if writer and epochs:
-                        writer.start_libid(
-                            libid_counter,
-                            t["RA_deg"],
-                            t["Dec_deg"],
-                            nobs=len(epochs),
-                            comment=t["Name"],
-                        )
-                        libid_counter += 1
-                        for epoch in epochs:
-                            writer.add_epoch(**epoch)
-                        writer.end_libid()
-                    if filters_used:
-                        if state is not None and filters_used[0] != state:
-                            swap_count_by_window[idx_w] += 1
-                        state = filters_used[-1]
-                        current_filter_by_window[idx_w] = state
-                        filters_used_set.update(filters_used)
-                    internal_changes += max(0, len(filters_used) - 1)
-                    window_slew_times.append(timing["slew_s"])
-                    window_airmasses.append(air)
-                    prev = t
-                    tracker.record_detection(
-                        t["Name"], timing["exposure_s"], filters_used, mjd=visit_mjd
-                    )
+            progress = True
+            while progress and deferred and window_sum < cap_s:
+                progress = False
+                # iterate over a snapshot so we can remove items during iteration
+                for t in list(deferred):
+                    if _attempt_schedule(t, allow_defer=False):
+                        deferred.remove(t)
+                        progress = True
 
             used_filters_csv = ",".join(sorted(filters_used_set))
             win = windows[idx_w]
@@ -849,6 +865,7 @@ def plan_twilight_range_with_caps(
                     if r["date"] == day.date().isoformat()
                     and r["twilight_window"] == window_label_out
                     and pd.notna(r.get("cadence_days_since"))
+                    and r.get("cadence_gate_passed") is True
                 ]
                 cad_by_filter: Dict[str, List[float]] = {}
                 for r in cad_rows:

--- a/twilight_planner_pkg/tests/test_cadence_promotion.py
+++ b/twilight_planner_pkg/tests/test_cadence_promotion.py
@@ -1,0 +1,104 @@
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pandas as pd
+from astropy.time import Time
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+from twilight_planner_pkg.config import PlannerConfig
+from twilight_planner_pkg.scheduler import plan_twilight_range_with_caps
+
+
+def _make_subset_csv(src: Path, out: Path, n: int = 2) -> tuple[Path, list[str]]:
+    df = pd.read_csv(src).head(n)
+    df.to_csv(out, index=False)
+    return out, df["name"].tolist()
+
+
+def test_cadence_promotion(tmp_path, monkeypatch):
+    data_path = (
+        Path(__file__).resolve().parents[2] / "data" / "ATLAS_2021_to25_cleaned.csv"
+    )
+    subset_csv, names = _make_subset_csv(data_path, tmp_path / "subset.csv", n=2)
+    name_a, name_b = names
+
+    from twilight_planner_pkg import scheduler
+
+    def mock_windows(date_local, loc, min_sun_alt_deg=-18.0, max_sun_alt_deg=0.0):
+        start = datetime(
+            date_local.year,
+            date_local.month,
+            date_local.day,
+            5,
+            0,
+            0,
+            tzinfo=timezone.utc,
+        )
+        end = start + timedelta(minutes=10)
+        return [
+            {"start": start, "end": end, "label": "morning", "night_date": date_local}
+        ]
+
+    def mock_best_time_with_moon(
+        sc, window, loc, step_min, min_alt_deg, min_moon_sep_deg
+    ):
+        start, _ = window
+        return 50.0, start + timedelta(minutes=5), 30.0, 0.0, 180.0
+
+    monkeypatch.setattr(scheduler, "twilight_windows_for_local_night", mock_windows)
+    monkeypatch.setattr(scheduler, "_best_time_with_moon", mock_best_time_with_moon)
+    monkeypatch.setattr(scheduler, "great_circle_sep_deg", lambda a, b, c, d: 0.0)
+    monkeypatch.setattr(scheduler, "allowed_filters_for_window", lambda *a, **k: ["g"])
+    monkeypatch.setattr(
+        scheduler, "allowed_filters_for_sun_alt", lambda alt, cfg: ["g"]
+    )
+
+    start_dt = datetime(2025, 7, 30, 5, 0, 0, tzinfo=timezone.utc)
+    start_mjd = Time(start_dt).mjd
+    threshold = start_mjd + 1.0 / 86400.0
+
+    def mock_gate(self, name, filt, now_mjd, target, jitter):
+        if name == name_b:
+            return now_mjd >= threshold
+        return True
+
+    monkeypatch.setattr(
+        scheduler.PriorityTracker, "cadence_gate", mock_gate, raising=False
+    )
+    monkeypatch.setattr(
+        scheduler.PriorityTracker, "cadence_bonus", lambda *a, **k: 0.0, raising=False
+    )
+
+    cfg = PlannerConfig(
+        lat_deg=0.0,
+        lon_deg=0.0,
+        height_m=0.0,
+        filters=["g"],
+        exposure_by_filter={"g": 1.0},
+        readout_s=1.0,
+        filter_change_s=0.0,
+        evening_cap_s=0.0,
+        morning_cap_s=600.0,
+        max_sn_per_night=2,
+        per_sn_cap_s=100.0,
+        min_moon_sep_by_filter={"g": 0.0},
+        require_single_time_for_all_filters=False,
+        min_alt_deg=0.0,
+        twilight_step_min=1,
+        allow_filter_changes_in_twilight=True,
+    )
+
+    pernight_df, _ = plan_twilight_range_with_caps(
+        csv_path=str(subset_csv),
+        outdir=str(tmp_path),
+        start_date="2025-07-30",
+        end_date="2025-07-30",
+        cfg=cfg,
+        verbose=False,
+    )
+
+    snb = pernight_df[pernight_df["SN"] == name_b].iloc[0]
+    visit_start = pd.to_datetime(snb["visit_start_utc"], utc=True)
+    assert visit_start >= start_dt + timedelta(seconds=1)
+    assert bool(snb["cadence_gate_passed"])

--- a/twilight_planner_pkg/tests/test_defer_queue.py
+++ b/twilight_planner_pkg/tests/test_defer_queue.py
@@ -1,0 +1,99 @@
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pandas as pd
+from astropy.time import Time
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+from twilight_planner_pkg.config import PlannerConfig
+from twilight_planner_pkg.scheduler import plan_twilight_range_with_caps
+
+
+def _make_subset_csv(src: Path, out: Path, n: int = 3) -> tuple[Path, list[str]]:
+    df = pd.read_csv(src).head(n)
+    df.to_csv(out, index=False)
+    return out, df["name"].tolist()
+
+
+def test_defer_queue(tmp_path, monkeypatch):
+    data_path = (
+        Path(__file__).resolve().parents[2] / "data" / "ATLAS_2021_to25_cleaned.csv"
+    )
+    subset_csv, names = _make_subset_csv(data_path, tmp_path / "subset.csv", n=3)
+    name_a, name_b, name_c = names
+
+    from twilight_planner_pkg import scheduler
+
+    def mock_windows(date_local, loc, min_sun_alt_deg=-18.0, max_sun_alt_deg=0.0):
+        start = datetime(
+            date_local.year,
+            date_local.month,
+            date_local.day,
+            5,
+            0,
+            0,
+            tzinfo=timezone.utc,
+        )
+        end = start + timedelta(minutes=10)
+        return [
+            {"start": start, "end": end, "label": "morning", "night_date": date_local}
+        ]
+
+    def mock_best_time_with_moon(
+        sc, window, loc, step_min, min_alt_deg, min_moon_sep_deg
+    ):
+        start, _ = window
+        return 50.0, start + timedelta(minutes=5), 30.0, 0.0, 180.0
+
+    monkeypatch.setattr(scheduler, "twilight_windows_for_local_night", mock_windows)
+    monkeypatch.setattr(scheduler, "_best_time_with_moon", mock_best_time_with_moon)
+    monkeypatch.setattr(scheduler, "great_circle_sep_deg", lambda a, b, c, d: 0.0)
+    monkeypatch.setattr(scheduler, "allowed_filters_for_window", lambda *a, **k: ["g"])
+    monkeypatch.setattr(
+        scheduler, "allowed_filters_for_sun_alt", lambda alt, cfg: ["g"]
+    )
+
+    start_dt = datetime(2025, 7, 30, 5, 0, 0, tzinfo=timezone.utc)
+    start_mjd = Time(start_dt).mjd
+    thresholds = {name_b: start_mjd + 1.0 / 86400.0, name_c: start_mjd + 5.0 / 86400.0}
+
+    def mock_gate(self, name, filt, now_mjd, target, jitter):
+        return now_mjd >= thresholds.get(name, start_mjd)
+
+    monkeypatch.setattr(
+        scheduler.PriorityTracker, "cadence_gate", mock_gate, raising=False
+    )
+    monkeypatch.setattr(
+        scheduler.PriorityTracker, "cadence_bonus", lambda *a, **k: 0.0, raising=False
+    )
+
+    cfg = PlannerConfig(
+        lat_deg=0.0,
+        lon_deg=0.0,
+        height_m=0.0,
+        filters=["g"],
+        exposure_by_filter={"g": 1.0},
+        readout_s=1.0,
+        filter_change_s=0.0,
+        evening_cap_s=0.0,
+        morning_cap_s=600.0,
+        max_sn_per_night=3,
+        per_sn_cap_s=100.0,
+        min_moon_sep_by_filter={"g": 0.0},
+        require_single_time_for_all_filters=False,
+        min_alt_deg=0.0,
+        twilight_step_min=1,
+        allow_filter_changes_in_twilight=True,
+    )
+
+    pernight_df, _ = plan_twilight_range_with_caps(
+        csv_path=str(subset_csv),
+        outdir=str(tmp_path),
+        start_date="2025-07-30",
+        end_date="2025-07-30",
+        cfg=cfg,
+        verbose=False,
+    )
+
+    assert (pernight_df["SN"] == name_b).any()


### PR DESCRIPTION
## Goal
- promote bands later in window and avoid writing ungated rows

## Plan Stage
- Stage 4 (per-filter cadence) — see `IMPLEMENTATION_PLAN.md`

## Changes
- record true cadence gate result at visit start
- route targets using cadence-gated first-filter cost
- mark Stage 4 complete in implementation plan
- retry deferred targets until no further progress to better utilize window time

## Assumptions & Units
- times in seconds; MJDs via `astropy.time.Time`

## Tests
- `ruff check twilight_planner_pkg/scheduler.py twilight_planner_pkg/tests/test_cadence_promotion.py twilight_planner_pkg/tests/test_defer_queue.py twilight_planner_pkg/tests/test_cadence_per_filter.py`
- `black --check twilight_planner_pkg/scheduler.py twilight_planner_pkg/tests/test_cadence_promotion.py twilight_planner_pkg/tests/test_defer_queue.py twilight_planner_pkg/tests/test_cadence_per_filter.py`
- `isort --check-only --profile black twilight_planner_pkg/scheduler.py`
- `mypy twilight_planner_pkg` *(fails: missing library stubs and type errors)*
- `pytest -q`

## SIMLIB Impact
- none

## Risk & Rollback
- low risk: revert commit


------
https://chatgpt.com/codex/tasks/task_e_68a1bce894d483219b088a9c78510fbc