### PR TITLE
Refine unique-first priorities and stratify nightly caps

### DIFF
--- a/notebook/README.md
+++ b/notebook/README.md
@@ -53,7 +53,7 @@ For each UTC date in `START_DATE` … `END_DATE`:
 4. **Filter eligible SNe by “lifetime”**: using discovery time and `TYPICAL_DAYS_BY_TYPE` (with a 1.2× safety factor via `parse_sn_type_to_window_days`), accept only SNe still in their typical observability window on this date.
 5. **Best time per SN (Moon‑aware)**: for each candidate, sample the two twilight windows at `TWILIGHT_STEP_MIN` minutes (here 2 min); call `_best_time_with_moon` to get the maximum altitude time that also honors Moon separation (scaled by Moon altitude/phase). Keep the better of the two windows.
 6. **Visible SN filter**: keep targets with a valid best time, max altitude ≥ `MIN_ALT_DEG` (here 20°), and a valid window index.
-7. **Priorities & global selection**: score with `PriorityTracker` (hybrid or LC). Sort by priority, then max altitude (descending) and take the top `MAX_SN_PER_NIGHT` (here 10) as the nightly candidate pool (still subject to per-window caps later).
+7. **Priorities & global selection**: score with `PriorityTracker` (hybrid or LC). Drop non‑positive scores under `unique_first`, sort by priority then max altitude, and cap per window using a stratified split of `MAX_SN_PER_NIGHT` (default infinity).
 
 ### 3. Scheduling Within Each Twilight Window
 For each window index `idx_w` present that night:
@@ -130,7 +130,7 @@ default priority strategy.
   `PER_SN_CAP_S=120` — bounds per-SN work (slew + readout + exposure + filter changes).  
   `MORNING_CAP_S=600`, `EVENING_CAP_S=600` — roughly 10 minutes each; ensures plans pack into tight twilight windows.  
   `TWILIGHT_STEP_MIN=2` — few-minute sampling captures altitude/Moon geometry changes without over-sampling.  
-  `MAX_SN_PER_NIGHT=10` — global nightly cap before window-level packing.
+  `MAX_SN_PER_NIGHT=float('inf')` — unlimited candidates; set finite for stress testing. If finite, cap is split between windows.
 - **Priority strategy:**  
   `PRIORITY_STRATEGY="hybrid"` with `HYBRID_DETECTIONS=2`, `HYBRID_EXPOSURE=300s`, `LC_DETECTIONS=5`, `LC_EXPOSURE=300s`.  
   Starts broad with quick detections; escalates to deeper coverage for promising SNe.

--- a/notebook/unique_first.ipynb
+++ b/notebook/unique_first.ipynb
@@ -2,14 +2,25 @@
  "cells": [
   {
    "cell_type": "code",
+   "execution_count": 19,
    "id": "initial_id",
    "metadata": {
-    "collapsed": true,
     "ExecuteTime": {
      "end_time": "2025-08-20T09:00:00.789271Z",
      "start_time": "2025-08-20T09:00:00.785488Z"
-    }
+    },
+    "collapsed": true
    },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CSV exists: True\n",
+      "Output dir: ../twilight_outputs\n"
+     ]
+    }
+   ],
    "source": [
     "# --- Imports and path setup ---\n",
     "import sys\n",
@@ -28,27 +39,19 @@
     "\n",
     "print(\"CSV exists:\", os.path.exists(CSV_PATH))\n",
     "print(\"Output dir:\", OUTDIR)"
-   ],
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "CSV exists: True\n",
-      "Output dir: ../twilight_outputs\n"
-     ]
-    }
-   ],
-   "execution_count": 19
+   ]
   },
   {
+   "cell_type": "code",
+   "execution_count": 20,
+   "id": "324e78473f36227d",
    "metadata": {
     "ExecuteTime": {
      "end_time": "2025-08-20T09:00:00.802981Z",
      "start_time": "2025-08-20T09:00:00.797848Z"
     }
    },
-   "cell_type": "code",
+   "outputs": [],
    "source": [
     "# ---- User-editable parameters ----\n",
     "\n",
@@ -117,7 +120,7 @@
     "MORNING_CAP_S = 'auto'\n",
     "EVENING_CAP_S = 'auto'\n",
     "TWILIGHT_STEP_MIN = 2\n",
-    "MAX_SN_PER_NIGHT = 100\n",
+    "MAX_SN_PER_NIGHT = float('inf')\n",
     "\n",
     "# -- Priority strategy --\n",
     "PRIORITY_STRATEGY = \"unique_first\"  # or \"lc\"\n",
@@ -161,19 +164,38 @@
     "DISC_COL = None\n",
     "NAME_COL = None\n",
     "TYPE_COL = None\n"
-   ],
-   "id": "324e78473f36227d",
-   "outputs": [],
-   "execution_count": 20
+   ]
   },
   {
+   "cell_type": "markdown",
+   "id": "24755894",
+   "metadata": {},
+   "source": [
+    "Default is unlimited; final executed visits are governed by twilight window time caps and overheads. Set a finite `MAX_SN_PER_NIGHT` only for stress-testing or intentional throttling."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "id": "557051d15bd9c327",
    "metadata": {
     "ExecuteTime": {
      "end_time": "2025-08-20T09:00:00.817212Z",
      "start_time": "2025-08-20T09:00:00.813021Z"
     }
    },
-   "cell_type": "code",
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "PlannerConfig(lat_deg=-30.2446, lon_deg=-70.7494, height_m=2663, min_alt_deg=20.0, twilight_sun_alt_min_deg=-15.0, twilight_sun_alt_max_deg=-5.0, filters=['g', 'r', 'i', 'z'], carousel_capacity=5, filter_change_s=120.0, readout_s=2.0, inter_exposure_min_s=15.0, filter_change_time_s=None, readout_time_s=None, exposure_by_filter={'g': 5.0, 'r': 5.0, 'i': 5.0, 'z': 5.0}, max_filters_per_visit=3, start_filter='g', sun_alt_policy=[(-18.0, -15.0, ['y', 'z', 'i']), (-15.0, -12.0, ['z', 'i', 'r']), (-12.0, 0.0, ['i', 'z', 'y'])], sun_alt_exposure_ladder=[], slew_small_deg=3.5, slew_small_time_s=4.0, slew_rate_deg_per_s=5.25, slew_settle_s=1.0, min_moon_sep_by_filter={'u': 80.0, 'g': 50.0, 'r': 35.0, 'i': 30.0, 'z': 25.0, 'y': 20.0}, require_single_time_for_all_filters=True, per_sn_cap_s=120.0, morning_cap_s='auto', evening_cap_s='auto', morning_twilight=None, evening_twilight=None, twilight_step_min=2, max_sn_per_night=100, hybrid_detections=2, hybrid_exposure_s=300.0, lc_detections=5, lc_exposure_s=300.0, priority_strategy='unique_first', unique_first_fill_with_color=True, unique_lookback_days=999.0, cadence_enable=True, cadence_per_filter=True, cadence_days_target=3.0, cadence_jitter_days=0.25, cadence_days_tolerance=1, cadence_bonus_sigma_days=0.5, cadence_bonus_weight=0.25, cadence_first_epoch_bonus_weight=0.0, pixel_scale_arcsec=0.2, zpt1s=None, k_m=None, fwhm_eff=None, read_noise_e=6.0, gain_e_per_adu=1.0, zpt_err_mag=0.01, dark_sky_mag=None, twilight_delta_mag=2.5, simlib_out='unique_first.simlib', simlib_survey='LSST', simlib_filters='grizy', simlib_pixsize=0.2, simlib_npe_pixel_saturate=1000000.0, simlib_photflag_saturate=4096, simlib_psf_unit='arcsec', typical_days_by_type={'Ia': 70, 'II-P': 100, 'II-L': 70, 'IIn': 120, 'IIb': 70, 'Ib': 60, 'Ic': 60}, default_typical_days=60, ra_col=None, dec_col=None, disc_col=None, name_col=None, type_col=None, current_mag_by_filter=None, current_alt_deg=None, current_mjd=None, sky_provider=None, allow_filter_changes_in_twilight=True)"
+      ]
+     },
+     "execution_count": 21,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "# ---- User-editable parameters ----\n",
     "PRIORITY_STRATEGY2 = \"unique_first\"\n",
@@ -246,25 +268,14 @@
     ")\n",
     "\n",
     "cfg2"
-   ],
-   "id": "557051d15bd9c327",
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "PlannerConfig(lat_deg=-30.2446, lon_deg=-70.7494, height_m=2663, min_alt_deg=20.0, twilight_sun_alt_min_deg=-15.0, twilight_sun_alt_max_deg=-5.0, filters=['g', 'r', 'i', 'z'], carousel_capacity=5, filter_change_s=120.0, readout_s=2.0, inter_exposure_min_s=15.0, filter_change_time_s=None, readout_time_s=None, exposure_by_filter={'g': 5.0, 'r': 5.0, 'i': 5.0, 'z': 5.0}, max_filters_per_visit=3, start_filter='g', sun_alt_policy=[(-18.0, -15.0, ['y', 'z', 'i']), (-15.0, -12.0, ['z', 'i', 'r']), (-12.0, 0.0, ['i', 'z', 'y'])], sun_alt_exposure_ladder=[], slew_small_deg=3.5, slew_small_time_s=4.0, slew_rate_deg_per_s=5.25, slew_settle_s=1.0, min_moon_sep_by_filter={'u': 80.0, 'g': 50.0, 'r': 35.0, 'i': 30.0, 'z': 25.0, 'y': 20.0}, require_single_time_for_all_filters=True, per_sn_cap_s=120.0, morning_cap_s='auto', evening_cap_s='auto', morning_twilight=None, evening_twilight=None, twilight_step_min=2, max_sn_per_night=100, hybrid_detections=2, hybrid_exposure_s=300.0, lc_detections=5, lc_exposure_s=300.0, priority_strategy='unique_first', unique_first_fill_with_color=True, unique_lookback_days=999.0, cadence_enable=True, cadence_per_filter=True, cadence_days_target=3.0, cadence_jitter_days=0.25, cadence_days_tolerance=1, cadence_bonus_sigma_days=0.5, cadence_bonus_weight=0.25, cadence_first_epoch_bonus_weight=0.0, pixel_scale_arcsec=0.2, zpt1s=None, k_m=None, fwhm_eff=None, read_noise_e=6.0, gain_e_per_adu=1.0, zpt_err_mag=0.01, dark_sky_mag=None, twilight_delta_mag=2.5, simlib_out='unique_first.simlib', simlib_survey='LSST', simlib_filters='grizy', simlib_pixsize=0.2, simlib_npe_pixel_saturate=1000000.0, simlib_photflag_saturate=4096, simlib_psf_unit='arcsec', typical_days_by_type={'Ia': 70, 'II-P': 100, 'II-L': 70, 'IIn': 120, 'IIb': 70, 'Ib': 60, 'Ic': 60}, default_typical_days=60, ra_col=None, dec_col=None, disc_col=None, name_col=None, type_col=None, current_mag_by_filter=None, current_alt_deg=None, current_mjd=None, sky_provider=None, allow_filter_changes_in_twilight=True)"
-      ]
-     },
-     "execution_count": 21,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "execution_count": 21
+   ]
   },
   {
-   "metadata": {},
    "cell_type": "code",
+   "execution_count": null,
+   "id": "7aaa9c674f3790d5",
+   "metadata": {},
+   "outputs": [],
    "source": [
     "# Execute the planner and return data frames\n",
     "RUN_LABEL = \"one_dec\"  # label for output files\n",
@@ -281,10 +292,7 @@
     "\n",
     "print(\"Per-SN rows:\", len(perSN_df_2), \"  Nights summary rows:\", len(nights_df_2))\n",
     "perSN_df_2.head(10)"
-   ],
-   "id": "7aaa9c674f3790d5",
-   "outputs": [],
-   "execution_count": null
+   ]
   }
  ],
  "metadata": {

--- a/twilight_planner_pkg/config.py
+++ b/twilight_planner_pkg/config.py
@@ -8,6 +8,7 @@ at Cerro Pach\u00f3n and can be customised for testing purposes.
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from math import inf
 from typing import Dict, List, Literal, Optional, Tuple
 
 
@@ -101,7 +102,7 @@ class PlannerConfig:
     evening_twilight: str | None = None
 
     twilight_step_min: int = 2
-    max_sn_per_night: int = 20
+    max_sn_per_night: float | int = inf
 
     # -- Priority tracking -------------------------------------------------
     hybrid_detections: int = 2
@@ -111,6 +112,10 @@ class PlannerConfig:
     priority_strategy: str = "hybrid"
     unique_first_fill_with_color: bool = True
     unique_lookback_days: float = 999.0
+    unique_first_drop_threshold: float = 0.0
+    """Drop `unique_first` rows with score <= this threshold."""
+    unique_first_resume_score: float = 0.0
+    """Score used after lookback days if repeats are allowed again."""
 
     # -- Cadence ----------------------------------------------------------
     cadence_enable: bool = True

--- a/twilight_planner_pkg/main.py
+++ b/twilight_planner_pkg/main.py
@@ -20,6 +20,14 @@ from .config import PlannerConfig
 from .scheduler import plan_twilight_range_with_caps
 
 
+def _parse_float_or_inf(val: str) -> float:
+    """Parse a float but accept aliases for infinity."""
+    v = str(val).strip().lower()
+    if v in {"inf", "+inf", "infinity", "+infinity", "none", "unlimited", "unlimit"}:
+        return float("inf")
+    return float(val)
+
+
 def build_parser():
     """Construct the command-line argument parser.
 
@@ -77,7 +85,12 @@ def build_parser():
         help="Cap seconds in morning twilight; number or 'auto' to use window duration",
     )
     p.add_argument("--per_sn_cap", type=float, default=120.0)
-    p.add_argument("--max_sn", type=int, default=10)
+    p.add_argument(
+        "--max_sn",
+        type=_parse_float_or_inf,
+        default=float("inf"),
+        help="Global candidate cap before time packing. Use a number or 'inf'/'none'/'unlimited'.",
+    )
     p.add_argument("--twilight_step", type=int, default=2)
     p.add_argument(
         "--evening-twilight",

--- a/twilight_planner_pkg/tests/test_strategy_unique_first.py
+++ b/twilight_planner_pkg/tests/test_strategy_unique_first.py
@@ -13,7 +13,7 @@ def test_unique_first_scoring() -> None:
     tracker = PriorityTracker()
     assert tracker.score("SN1", strategy="unique_first") == 1.0
     tracker.record_detection("SN1", 10.0, ["g"])
-    assert tracker.score("SN1", strategy="unique_first") == 0.0
+    assert tracker.score("SN1", strategy="unique_first") == -1.0
 
 
 def test_scheduler_unique_first_no_repeats(tmp_path, monkeypatch) -> None:
@@ -76,3 +76,63 @@ def test_scheduler_unique_first_no_repeats(tmp_path, monkeypatch) -> None:
     assert row["n_planned"] == 2
     assert row["unique_targets_observed"] == 2
     assert row["repeat_fraction"] == 0.0
+
+
+def test_scheduler_unique_first_filters_after_detection(tmp_path, monkeypatch) -> None:
+    """Second night drops targets already seen once."""
+
+    df = pd.DataFrame(
+        {
+            "ra": [0.0],
+            "dec": [0.0],
+            "discoverydate": ["2023-12-01T00:00:00Z"],
+            "name": ["SN1"],
+            "type": ["Ia"],
+        }
+    )
+    csv = tmp_path / "cat.csv"
+    df.to_csv(csv, index=False)
+
+    from twilight_planner_pkg import scheduler
+
+    def mock_twilight_windows_for_local_night(
+        date_local, loc, min_sun_alt_deg=-18.0, max_sun_alt_deg=0.0
+    ):
+        start = datetime(
+            date_local.year,
+            date_local.month,
+            date_local.day,
+            5,
+            0,
+            0,
+            tzinfo=timezone.utc,
+        )
+        end = start + timedelta(minutes=30)
+        return [
+            {"start": start, "end": end, "label": "morning", "night_date": date_local}
+        ]
+
+    def mock_best_time_with_moon(
+        sc, window, loc, step_min, min_alt_deg, min_moon_sep_deg
+    ):
+        start, _ = window
+        return 50.0, start + timedelta(minutes=5), 0.0, 0.0, 180.0
+
+    monkeypatch.setattr(
+        scheduler,
+        "twilight_windows_for_local_night",
+        mock_twilight_windows_for_local_night,
+    )
+    monkeypatch.setattr(scheduler, "_best_time_with_moon", mock_best_time_with_moon)
+
+    cfg = PlannerConfig(
+        filters=["i"],
+        morning_cap_s=1000.0,
+        evening_cap_s=1000.0,
+        priority_strategy="unique_first",
+    )
+    pernight, nights = plan_twilight_range_with_caps(
+        str(csv), tmp_path, "2024-01-01", "2024-01-02", cfg, verbose=False
+    )
+    assert len(nights) == 1
+    assert nights.iloc[0]["n_planned"] == 1


### PR DESCRIPTION
## Goal
- Improve unique-first scheduling and avoid starving twilight windows

## Plan Stage
- Stage 7: Reporting & comparatives ([IMPLEMENTATION_PLAN.md](./IMPLEMENTATION_PLAN.md))

## Changes
- Return negative priority after first detection with optional lookback-based resume score
- Drop non-positive unique-first rows early and enforce stratified nightly cap with diagnostics
- Default `max_sn_per_night` to infinity and allow CLI aliases like `inf`/`none`
- Expose per-window quota diagnostics and add single-window quota test
- Document unlimited default and unique-first behaviour in READMEs

## Assumptions & Units
- Time caps in seconds; infinity represented with `float('inf')`

## Tests
- `ruff check . --exclude notebook`
- `black --check . --exclude notebook`
- `isort --check-only . --profile black --skip notebook`
- `mypy twilight_planner_pkg`
- `pytest -q`

## SIMLIB Impact
- None

## Risk & Rollback
- Revert commit `1733ba4` to restore previous behaviour


------
https://chatgpt.com/codex/tasks/task_e_68a59bc010208321a5ba59115dab64c1