### PR TITLE
Fix rest-frame slice to prevent QC IndexError

### DIFF
--- a/Motivation/tw_qc.py
+++ b/Motivation/tw_qc.py
@@ -93,9 +93,11 @@ def nosat_mask_for_run(
             z = pd.to_numeric(row.get("z", np.nan), errors="coerce")
             pk = pd.to_numeric(row.get("PKMJD", np.nan), errors="coerce")
             if np.isfinite(z) and np.isfinite(pk):
-                t_rest = (phot_df.loc[a:b, "MJD"].to_numpy() - pk) / (1.0 + z)
+                mjd_col = phot_df.columns.get_loc("MJD")
+                t_rest = (phot_df.iloc[a:b, mjd_col].to_numpy() - pk) / (1.0 + z)
                 mwin = (t_rest >= rest_window[0]) & (t_rest <= rest_window[1])
-                if np.any(sat_epoch[a:b][mwin]):
+                sat_slice = sat_epoch[a:b]
+                if np.any(sat_slice & mwin):
                     ok.at[i] = False
                 continue
         if np.any(sat_epoch[a:b]):


### PR DESCRIPTION
## Goal:
- avoid IndexError in QC saturation check by aligning slice semantics

## Plan Stage:
- N/A

## Changes:
- switch to position-based `iloc` for rest-frame MJD slicing
- guard saturation mask with element-wise combination

## Assumptions & Units:
- none

## Tests:
- `ruff check Motivation/tw_qc.py`
- `black --check Motivation/tw_qc.py`
- `isort --check-only Motivation/tw_qc.py`
- `mypy twilight_planner_pkg`
- `pytest -q`

## SIMLIB Impact:
- none

## Risk & Rollback:
- revert commit if unexpected QC behavior arises

------
https://chatgpt.com/codex/tasks/task_e_68b7471acaec8321a786dc87fc46c18f