### PR TITLE
Fix diversity bonus and filter heuristics

### DIFF
--- a/twilight_planner_pkg/config.py
+++ b/twilight_planner_pkg/config.py
@@ -457,14 +457,6 @@ class PlannerConfig:
         # Normalise core filter configuration to lowercase to keep scheduler internals
         # case-insensitive while still permitting uppercase inputs in notebooks.
         self.filters = _norm_filter_list(self.filters)
-        seen: set[str] = set()
-        deduped: list[str] = []
-        for f in self.filters:
-            if f in seen:
-                continue
-            deduped.append(f)
-            seen.add(f)
-        self.filters = deduped
 
         if self.start_filter is not None:
             start_norm = _norm_filter_name(self.start_filter)


### PR DESCRIPTION
- **Goal:** Restore scheduler behaviours that regressions uncovered in the new unit tests.
- **Plan Stage:** N/A
- **Changes:**
  - Ensure the per-filter diversity bonus still boosts unseen bands even when the cadence term is zero.
  - Restrict the bright-twilight filter candidate list using the heuristic order while still honouring explicit per-target magnitudes.
  - Merge custom sky brightness maps with SMTN-002 defaults and keep planner filter lists from deduplicating user input.
- **Assumptions & Units:** Uses SMTN-002 zenith dark-sky magnitudes (mag/arcsec²); cadence weights remain dimensionless multipliers.
- **Tests:** `pytest -q`
- **SIMLIB Impact:** None; changes only affect candidate selection heuristics prior to writing outputs.
- **Risk & Rollback:** Low risk. Revert commit f72a917be22f90a39f9ade6704aabcc23cfa2cad to restore previous behaviour if issues arise.


------
https://chatgpt.com/codex/tasks/task_e_68cefee41cd08321a954aac55c2467f6