### PR TITLE
Update filter priority test for current filter bias

### DIFF
--- a/twilight_planner_pkg/tests/test_planner_features.py
+++ b/twilight_planner_pkg/tests/test_planner_features.py
@@ -85,7 +85,7 @@ def test_pick_first_filter_priority():
     f2 = pick_first_filter_for_target(
         "SN_B", "Ia", tracker, ["g", "r"], cfg, current_filter="g"
     )
-    assert f2 == "r"  # red preference in LC stage
+    assert f2 == "g"  # escalated target prefers to stay on current filter if viable
 
 
 def test_per_sn_cap_allows_one():


### PR DESCRIPTION
- **Goal:** Align `test_pick_first_filter_priority` with the planner's updated behaviour that avoids unnecessary filter swaps once a target is escalated.
- **Plan Stage:** N/A
- **Changes:**
  - Updated the escalated target assertion in `test_pick_first_filter_priority` to expect the current filter when it remains a viable option, matching the implementation's bias to stay on the active filter.
- **Assumptions & Units:** No new assumptions; unit handling unchanged.
- **Tests:** `pytest -q`
- **SIMLIB Impact:** None.
- **Risk & Rollback:** Low risk; revert commit to restore previous expectation.


------
https://chatgpt.com/codex/tasks/task_e_68d4e31c57108321a0a9c96250cdc9da